### PR TITLE
Edit code block feature addition

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,310 +1,328 @@
-import { app, BrowserWindow, ipcMain, shell, dialog } from 'electron';
-import { AppManager } from "../src/logic/appManager"
-import * as path from 'path';
-import { ElectronEvents, FileName } from '../src/types/types';
+import { app, BrowserWindow, ipcMain, shell, dialog } from "electron";
+import { AppManager } from "../src/logic/appManager";
+import * as path from "path";
+import { ElectronEvents, FileName } from "../src/types/types";
 let mainWindow: BrowserWindow | null = null;
 let pegApp: AppManager | null = null;
 const createWindow = async () => {
+	mainWindow = new BrowserWindow({
+		show: false,
+		width: 1280,
+		height: 720,
+		maxWidth: 1280,
+		maxHeight: 720,
+		minWidth: 1280,
+		minHeight: 720,
+		icon: path.join(__dirname, "..", "icon.png"),
+		frame: false,
+		titleBarStyle: "hiddenInset",
+		webPreferences: {
+			nodeIntegration: true,
+			preload: path.join(__dirname, "preload.js"),
+		},
+	});
+	if (mainWindow !== null) {
+		pegApp = AppManager.getInstance(mainWindow);
+		await pegApp.diskManager.cacheData("");
+		pegApp.run();
+	}
 
-  mainWindow = new BrowserWindow({
-    show: false,
-    width: 1280,
-    height: 720,
-    maxWidth: 1280,
-    maxHeight: 720,
-    minWidth: 1280,
-    minHeight: 720,
-    icon: path.join(__dirname, "..", "icon.png"),
-    frame: false,
-    titleBarStyle: 'hiddenInset',
-    webPreferences: {
-      nodeIntegration: true,
-      preload: path.join(__dirname, 'preload.js'),
-    },
-  });
-  if (mainWindow !== null) {
-    pegApp = AppManager.getInstance(mainWindow)
-    await pegApp.diskManager.cacheData("")
-    pegApp.run()
-  }
+	if (app.isPackaged) {
+		mainWindow.loadURL(`file://${__dirname}/../index.html`);
+	} else {
+		mainWindow.loadURL("http://localhost:3000/index.html");
+		require("electron-reload")(__dirname, {
+			electron: path.join(
+				__dirname,
+				"..",
+				"..",
+				"node_modules",
+				".bin",
+				"electron" + (process.platform === "win32" ? ".cmd" : "")
+			),
+			forceHardReset: true,
+			hardResetMethod: "exit",
+		});
+	}
 
-  if (app.isPackaged) {
-    mainWindow.loadURL(`file://${__dirname}/../index.html`);
-  } else {
-    mainWindow.loadURL('http://localhost:3000/index.html');
-    require('electron-reload')(__dirname, {
-      electron: path.join(__dirname,
-        '..',
-        '..',
-        'node_modules',
-        '.bin',
-        'electron' + (process.platform === "win32" ? ".cmd" : "")),
-      forceHardReset: true,
-      hardResetMethod: 'exit'
-    });
-  }
+	mainWindow.on("ready-to-show", () => {
+		if (pegApp) {
+			pegApp.diskManager.cacheData("");
+			pegApp.diskManager.readSettings(
+				ElectronEvents.ReadSettings,
+				FileName.settings
+			);
+			pegApp.diskManager.readSettings(
+				ElectronEvents.ReadCustomCodes,
+				FileName.customCodes
+			);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.diskManager.cacheData("");
+				pegApp.diskManager.readSettings(
+					ElectronEvents.ReadSettings,
+					FileName.settings
+				);
+				pegApp.diskManager.readSettings(
+					ElectronEvents.ReadCustomCodes,
+					FileName.customCodes
+				);
+			}
+		}
+		if (!mainWindow) {
+			throw new Error('"mainWindow" is not defined');
+		}
+		if (process.env.START_MINIMIZED) {
+			mainWindow.minimize();
+		} else {
+			mainWindow.show();
+		}
+	});
 
-  mainWindow.on('ready-to-show', () => {
-    if (pegApp) {
-      pegApp.diskManager.cacheData("")
-      pegApp.diskManager.readSettings(ElectronEvents.ReadSettings, FileName.settings)
-      pegApp.diskManager.readSettings(ElectronEvents.ReadCustomCodes, FileName.customCodes)
-    } else {
-      if (mainWindow !== null) {
-        pegApp = AppManager.getInstance(mainWindow)
-        pegApp.diskManager.cacheData("")
-        pegApp.diskManager.readSettings(ElectronEvents.ReadSettings, FileName.settings)
-        pegApp.diskManager.readSettings(ElectronEvents.ReadCustomCodes, FileName.customCodes)
-      }
-    }
-    if (!mainWindow) {
-      throw new Error('"mainWindow" is not defined');
-    }
-    if (process.env.START_MINIMIZED) {
-      mainWindow.minimize();
-    } else {
-      mainWindow.show();
-    }
-  });
+	mainWindow.on("closed", async () => {
+		mainWindow = null;
+	});
 
-  mainWindow.on('closed', async () => {
-    mainWindow = null;
-  });
+	// const menuBuilder = new MenuBuilder(mainWindow);
+	// menuBuilder.buildMenu();
 
-  // const menuBuilder = new MenuBuilder(mainWindow);
-  // menuBuilder.buildMenu();
+	// Open urls in the user's browser
+	mainWindow.webContents.on("new-window", (event, url) => {
+		event.preventDefault();
+		shell.openExternal(url);
+	});
 
-  // Open urls in the user's browser
-  mainWindow.webContents.on('new-window', (event, url) => {
-    event.preventDefault();
-    shell.openExternal(url);
-  });
-
-  // Remove this if your app does not use auto updates
-  // eslint-disable-next-line
-  // new AppUpdater();
-
+	// Remove this if your app does not use auto updates
+	// eslint-disable-next-line
+	// new AppUpdater();
 };
-app.on('window-all-closed', () => {
-
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
+app.on("window-all-closed", () => {
+	if (process.platform !== "darwin") {
+		app.quit();
+	}
 });
 
-
-ipcMain.on(ElectronEvents.Scan, (event: Electron.IpcMainEvent, fileName: string,) => {
-  if (pegApp) {
-    pegApp.Scan(event, fileName)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.Scan(event, fileName)
-
-    }
-  }
-}
-)
+ipcMain.on(
+	ElectronEvents.Scan,
+	(event: Electron.IpcMainEvent, fileName: string) => {
+		if (pegApp) {
+			pegApp.Scan(event, fileName);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.Scan(event, fileName);
+			}
+		}
+	}
+);
 
 ipcMain.on(ElectronEvents.ClientUp, () => {
-  if (pegApp) {
-    pegApp.ClientUp()
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.ClientUp()
+	if (pegApp) {
+		pegApp.ClientUp();
+	} else {
+		if (mainWindow !== null) {
+			pegApp = AppManager.getInstance(mainWindow);
+			pegApp.ClientUp();
+		}
+	}
+});
+ipcMain.on(
+	ElectronEvents.FreshDriveScan,
+	(event: Electron.IpcMainEvent, fileName: string) => {
+		if (pegApp) {
+			pegApp.FreshScan(event, fileName);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.FreshScan(event, fileName);
+			}
+		}
+	}
+);
 
-    }
-  }
-}
-)
-ipcMain.on(ElectronEvents.FreshDriveScan, (event: Electron.IpcMainEvent, fileName: string,) => {
-  if (pegApp) {
-    pegApp.FreshScan(event, fileName)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.FreshScan(event, fileName)
+ipcMain.on(
+	ElectronEvents.SaveMap,
+	(event: Electron.IpcMainEvent, file: string) => {
+		if (pegApp) {
+			pegApp.fileSave(event, file);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.fileSave(event, file);
+			}
+		}
+	}
+);
 
-    }
-  }
-}
-)
+ipcMain.on(
+	ElectronEvents.SaveSettings,
+	(event: Electron.IpcMainEvent, file: string) => {
+		if (pegApp) {
+			pegApp.SaveSetting(event, file, ElectronEvents.SaveSettings);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.SaveSetting(event, file, ElectronEvents.SaveSettings);
+			}
+		}
+	}
+);
 
+ipcMain.on(
+	ElectronEvents.SaveCustomCodes,
+	(event: Electron.IpcMainEvent, file: string) => {
+		console.log("save file");
+		if (pegApp) {
+			pegApp.SaveSetting(event, file, ElectronEvents.SaveCustomCodes);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.SaveSetting(event, file, ElectronEvents.SaveCustomCodes);
+			}
+		}
+	}
+);
 
-ipcMain.on(ElectronEvents.SaveMap, (event: Electron.IpcMainEvent, file: string,) => {
-  if (pegApp) {
-    pegApp.fileSave(event, file)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.fileSave(event, file)
+ipcMain.on(
+	ElectronEvents.Savefile,
+	(
+		event: Electron.IpcMainEvent,
+		data: { fileData: string; path: string[] }
+	) => {
+		if (pegApp) {
+			pegApp.writeFile(event, data);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.writeFile(event, data);
+			}
+		}
+	}
+);
 
-    }
-  }
-}
-)
+ipcMain.on(
+	ElectronEvents.InstallKmk,
+	(event: Electron.IpcMainEvent, path: string) => {
+		if (pegApp) {
+			pegApp.InstallKmk(path);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.InstallKmk(path);
+			}
+		}
+	}
+);
 
-ipcMain.on(ElectronEvents.SaveSettings, (event: Electron.IpcMainEvent, file: string,) => {
-  if (pegApp) {
-    pegApp.SaveSetting(event, file, ElectronEvents.SaveSettings)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.SaveSetting(event, file, ElectronEvents.SaveSettings)
+ipcMain.on(
+	ElectronEvents.DownLoadAndInstallLib,
+	(event: Electron.IpcMainEvent, data: { boardName: string; path: string }) => {
+		if (pegApp) {
+			pegApp.DownloadAndInstallLib(data.boardName, data.path);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.DownloadAndInstallLib(data.boardName, data.path);
+			}
+		}
+	}
+);
 
-    }
-  }
-}
-)
-
-ipcMain.on(ElectronEvents.SaveCustomCodes, (event: Electron.IpcMainEvent, file: string,) => {
-  console.log("save file")
-  if (pegApp) {
-    pegApp.SaveSetting(event, file, ElectronEvents.SaveCustomCodes)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.SaveSetting(event, file, ElectronEvents.SaveCustomCodes)
-
-    }
-  }
-}
-)
-
-
-ipcMain.on(ElectronEvents.Savefile, (event: Electron.IpcMainEvent, data: { fileData: string, path: string[] }) => {
-  if (pegApp) {
-    pegApp.writeFile(event, data)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.writeFile(event, data)
-
-    }
-  }
-}
-)
-
-ipcMain.on(ElectronEvents.InstallKmk, (event: Electron.IpcMainEvent, path: string) => {
-  if (pegApp) {
-    pegApp.InstallKmk(path)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.InstallKmk(path)
-
-    }
-  }
-}
-)
-
-ipcMain.on(ElectronEvents.DownLoadAndInstallLib, (event: Electron.IpcMainEvent, data: { boardName: string, path: string, }) => {
-  if (pegApp) {
-    pegApp.DownloadAndInstallLib(data.boardName, data.path)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.DownloadAndInstallLib(data.boardName, data.path)
-    }
-  }
-}
-)
-
-ipcMain.on(ElectronEvents.SaveOled, (event: Electron.IpcMainEvent, data: { fileData: number[][], fileNumber: number | string }) => {
-  if (pegApp) {
-    pegApp.oledSave(event, data)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.oledSave(event, data)
-
-    }
-  }
-}
-)
-ipcMain.on(ElectronEvents.ReadOled, (event: Electron.IpcMainEvent, fileNumber: number) => {
-  if (pegApp) {
-    pegApp.oledread(event, fileNumber)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.oledread(event, fileNumber)
-
-    }
-  }
-}
-)
+ipcMain.on(
+	ElectronEvents.SaveOled,
+	(
+		event: Electron.IpcMainEvent,
+		data: { fileData: number[][]; fileNumber: number | string }
+	) => {
+		if (pegApp) {
+			pegApp.oledSave(event, data);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.oledSave(event, data);
+			}
+		}
+	}
+);
+ipcMain.on(
+	ElectronEvents.ReadOled,
+	(event: Electron.IpcMainEvent, fileNumber: number) => {
+		if (pegApp) {
+			pegApp.oledread(event, fileNumber);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.oledread(event, fileNumber);
+			}
+		}
+	}
+);
 
 ipcMain.on(ElectronEvents.DownLoadKmk, (event: Electron.IpcMainEvent) => {
-  if (pegApp) {
-    pegApp.DownloadKmk()
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.DownloadKmk()
+	if (pegApp) {
+		pegApp.DownloadKmk();
+	} else {
+		if (mainWindow !== null) {
+			pegApp = AppManager.getInstance(mainWindow);
+			pegApp.DownloadKmk();
+		}
+	}
+});
 
-    }
-  }
-}
-)
+ipcMain.on(
+	ElectronEvents.SetProPlan,
+	(event: Electron.IpcMainEvent, id: string) => {
+		if (pegApp) {
+			pegApp.saveProPlan(event, id);
+		} else {
+			if (mainWindow !== null) {
+				pegApp = AppManager.getInstance(mainWindow);
+				pegApp.saveProPlan(event, id);
+			}
+		}
+	}
+);
 
-
-ipcMain.on(ElectronEvents.SetProPlan, (event: Electron.IpcMainEvent, id: string) => {
-  if (pegApp) {
-    pegApp.saveProPlan(event, id)
-  } else {
-    if (mainWindow !== null) {
-      pegApp = AppManager.getInstance(mainWindow)
-      pegApp.saveProPlan(event, id)
-
-    }
-  }
-}
-)
-
-
-
-ipcMain.on(ElectronEvents.FilePicker, async (event: Electron.IpcMainEvent, file: string,) => {
-  if (mainWindow !== null) {
-    const drivePath = await dialog.showOpenDialogSync(mainWindow, {
-      properties: ['openFile', 'openDirectory']
-    })
-    event.reply(ElectronEvents.FilePickerClose, drivePath ? drivePath[0] : '')
-  }
-}
-)
-
+ipcMain.on(
+	ElectronEvents.FilePicker,
+	async (event: Electron.IpcMainEvent, file: string) => {
+		if (mainWindow !== null) {
+			const drivePath = await dialog.showOpenDialogSync(mainWindow, {
+				properties: ["openFile", "openDirectory"],
+			});
+			event.reply(
+				ElectronEvents.FilePickerClose,
+				drivePath ? drivePath[0] : ""
+			);
+		}
+	}
+);
 
 ipcMain.on(ElectronEvents.WindowClose, (event: Electron.IpcMainEvent) => {
-  if (mainWindow !== null) {
-    mainWindow.close()
-  }
-}
-)
+	if (mainWindow !== null) {
+		mainWindow.close();
+	}
+});
+ipcMain.on(ElectronEvents.OpenFile, (event: Electron.IpcMainEvent) => {
+	shell.openPath(pegApp?.diskManager.getDrivePath() + "/main.py");
+});
 ipcMain.on(ElectronEvents.WindowFullScreen, (event: Electron.IpcMainEvent) => {
-  if (mainWindow !== null) {
-    mainWindow.fullScreen = !mainWindow.fullScreen
-  }
-}
-)
+	if (mainWindow !== null) {
+		mainWindow.fullScreen = !mainWindow.fullScreen;
+	}
+});
 ipcMain.on(ElectronEvents.WindowMinimize, (event: Electron.IpcMainEvent) => {
-  if (mainWindow !== null) {
-    mainWindow.minimize()
-  }
-}
-)
-
-
-
+	if (mainWindow !== null) {
+		mainWindow.minimize();
+	}
+});
 
 app.whenReady().then(() => {
-  createWindow()
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      createWindow()
-    }
-  });
-
-
-})
+	createWindow();
+	app.on("activate", () => {
+		if (BrowserWindow.getAllWindows().length === 0) {
+			createWindow();
+		}
+	});
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,328 +1,312 @@
-import { app, BrowserWindow, ipcMain, shell, dialog } from "electron";
-import { AppManager } from "../src/logic/appManager";
-import * as path from "path";
-import { ElectronEvents, FileName } from "../src/types/types";
+import { app, BrowserWindow, ipcMain, shell, dialog } from 'electron';
+import { AppManager } from "../src/logic/appManager"
+import * as path from 'path';
+import { ElectronEvents, FileName } from '../src/types/types';
 let mainWindow: BrowserWindow | null = null;
 let pegApp: AppManager | null = null;
 const createWindow = async () => {
-	mainWindow = new BrowserWindow({
-		show: false,
-		width: 1280,
-		height: 720,
-		maxWidth: 1280,
-		maxHeight: 720,
-		minWidth: 1280,
-		minHeight: 720,
-		icon: path.join(__dirname, "..", "icon.png"),
-		frame: false,
-		titleBarStyle: "hiddenInset",
-		webPreferences: {
-			nodeIntegration: true,
-			preload: path.join(__dirname, "preload.js"),
-		},
-	});
-	if (mainWindow !== null) {
-		pegApp = AppManager.getInstance(mainWindow);
-		await pegApp.diskManager.cacheData("");
-		pegApp.run();
-	}
 
-	if (app.isPackaged) {
-		mainWindow.loadURL(`file://${__dirname}/../index.html`);
-	} else {
-		mainWindow.loadURL("http://localhost:3000/index.html");
-		require("electron-reload")(__dirname, {
-			electron: path.join(
-				__dirname,
-				"..",
-				"..",
-				"node_modules",
-				".bin",
-				"electron" + (process.platform === "win32" ? ".cmd" : "")
-			),
-			forceHardReset: true,
-			hardResetMethod: "exit",
-		});
-	}
+  mainWindow = new BrowserWindow({
+    show: false,
+    width: 1280,
+    height: 720,
+    maxWidth: 1280,
+    maxHeight: 720,
+    minWidth: 1280,
+    minHeight: 720,
+    icon: path.join(__dirname, "..", "icon.png"),
+    frame: false,
+    titleBarStyle: 'hiddenInset',
+    webPreferences: {
+      nodeIntegration: true,
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+  if (mainWindow !== null) {
+    pegApp = AppManager.getInstance(mainWindow)
+    await pegApp.diskManager.cacheData("")
+    pegApp.run()
+  }
 
-	mainWindow.on("ready-to-show", () => {
-		if (pegApp) {
-			pegApp.diskManager.cacheData("");
-			pegApp.diskManager.readSettings(
-				ElectronEvents.ReadSettings,
-				FileName.settings
-			);
-			pegApp.diskManager.readSettings(
-				ElectronEvents.ReadCustomCodes,
-				FileName.customCodes
-			);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.diskManager.cacheData("");
-				pegApp.diskManager.readSettings(
-					ElectronEvents.ReadSettings,
-					FileName.settings
-				);
-				pegApp.diskManager.readSettings(
-					ElectronEvents.ReadCustomCodes,
-					FileName.customCodes
-				);
-			}
-		}
-		if (!mainWindow) {
-			throw new Error('"mainWindow" is not defined');
-		}
-		if (process.env.START_MINIMIZED) {
-			mainWindow.minimize();
-		} else {
-			mainWindow.show();
-		}
-	});
+  if (app.isPackaged) {
+    mainWindow.loadURL(`file://${__dirname}/../index.html`);
+  } else {
+    mainWindow.loadURL('http://localhost:3000/index.html');
+    require('electron-reload')(__dirname, {
+      electron: path.join(__dirname,
+        '..',
+        '..',
+        'node_modules',
+        '.bin',
+        'electron' + (process.platform === "win32" ? ".cmd" : "")),
+      forceHardReset: true,
+      hardResetMethod: 'exit'
+    });
+  }
 
-	mainWindow.on("closed", async () => {
-		mainWindow = null;
-	});
+  mainWindow.on('ready-to-show', () => {
+    if (pegApp) {
+      pegApp.diskManager.cacheData("")
+      pegApp.diskManager.readSettings(ElectronEvents.ReadSettings, FileName.settings)
+      pegApp.diskManager.readSettings(ElectronEvents.ReadCustomCodes, FileName.customCodes)
+    } else {
+      if (mainWindow !== null) {
+        pegApp = AppManager.getInstance(mainWindow)
+        pegApp.diskManager.cacheData("")
+        pegApp.diskManager.readSettings(ElectronEvents.ReadSettings, FileName.settings)
+        pegApp.diskManager.readSettings(ElectronEvents.ReadCustomCodes, FileName.customCodes)
+      }
+    }
+    if (!mainWindow) {
+      throw new Error('"mainWindow" is not defined');
+    }
+    if (process.env.START_MINIMIZED) {
+      mainWindow.minimize();
+    } else {
+      mainWindow.show();
+    }
+  });
 
-	// const menuBuilder = new MenuBuilder(mainWindow);
-	// menuBuilder.buildMenu();
+  mainWindow.on('closed', async () => {
+    mainWindow = null;
+  });
 
-	// Open urls in the user's browser
-	mainWindow.webContents.on("new-window", (event, url) => {
-		event.preventDefault();
-		shell.openExternal(url);
-	});
+  // const menuBuilder = new MenuBuilder(mainWindow);
+  // menuBuilder.buildMenu();
 
-	// Remove this if your app does not use auto updates
-	// eslint-disable-next-line
-	// new AppUpdater();
+  // Open urls in the user's browser
+  mainWindow.webContents.on('new-window', (event, url) => {
+    event.preventDefault();
+    shell.openExternal(url);
+  });
+
+  // Remove this if your app does not use auto updates
+  // eslint-disable-next-line
+  // new AppUpdater();
+
 };
-app.on("window-all-closed", () => {
-	if (process.platform !== "darwin") {
-		app.quit();
-	}
+app.on('window-all-closed', () => {
+
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
 });
 
-ipcMain.on(
-	ElectronEvents.Scan,
-	(event: Electron.IpcMainEvent, fileName: string) => {
-		if (pegApp) {
-			pegApp.Scan(event, fileName);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.Scan(event, fileName);
-			}
-		}
-	}
-);
+
+ipcMain.on(ElectronEvents.Scan, (event: Electron.IpcMainEvent, fileName: string,) => {
+  if (pegApp) {
+    pegApp.Scan(event, fileName)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.Scan(event, fileName)
+
+    }
+  }
+}
+)
 
 ipcMain.on(ElectronEvents.ClientUp, () => {
-	if (pegApp) {
-		pegApp.ClientUp();
-	} else {
-		if (mainWindow !== null) {
-			pegApp = AppManager.getInstance(mainWindow);
-			pegApp.ClientUp();
-		}
-	}
-});
-ipcMain.on(
-	ElectronEvents.FreshDriveScan,
-	(event: Electron.IpcMainEvent, fileName: string) => {
-		if (pegApp) {
-			pegApp.FreshScan(event, fileName);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.FreshScan(event, fileName);
-			}
-		}
-	}
-);
+  if (pegApp) {
+    pegApp.ClientUp()
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.ClientUp()
 
-ipcMain.on(
-	ElectronEvents.SaveMap,
-	(event: Electron.IpcMainEvent, file: string) => {
-		if (pegApp) {
-			pegApp.fileSave(event, file);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.fileSave(event, file);
-			}
-		}
-	}
-);
+    }
+  }
+}
+)
+ipcMain.on(ElectronEvents.FreshDriveScan, (event: Electron.IpcMainEvent, fileName: string,) => {
+  if (pegApp) {
+    pegApp.FreshScan(event, fileName)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.FreshScan(event, fileName)
 
-ipcMain.on(
-	ElectronEvents.SaveSettings,
-	(event: Electron.IpcMainEvent, file: string) => {
-		if (pegApp) {
-			pegApp.SaveSetting(event, file, ElectronEvents.SaveSettings);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.SaveSetting(event, file, ElectronEvents.SaveSettings);
-			}
-		}
-	}
-);
+    }
+  }
+}
+)
 
-ipcMain.on(
-	ElectronEvents.SaveCustomCodes,
-	(event: Electron.IpcMainEvent, file: string) => {
-		console.log("save file");
-		if (pegApp) {
-			pegApp.SaveSetting(event, file, ElectronEvents.SaveCustomCodes);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.SaveSetting(event, file, ElectronEvents.SaveCustomCodes);
-			}
-		}
-	}
-);
 
-ipcMain.on(
-	ElectronEvents.Savefile,
-	(
-		event: Electron.IpcMainEvent,
-		data: { fileData: string; path: string[] }
-	) => {
-		if (pegApp) {
-			pegApp.writeFile(event, data);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.writeFile(event, data);
-			}
-		}
-	}
-);
+ipcMain.on(ElectronEvents.SaveMap, (event: Electron.IpcMainEvent, file: string,) => {
+  if (pegApp) {
+    pegApp.fileSave(event, file)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.fileSave(event, file)
 
-ipcMain.on(
-	ElectronEvents.InstallKmk,
-	(event: Electron.IpcMainEvent, path: string) => {
-		if (pegApp) {
-			pegApp.InstallKmk(path);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.InstallKmk(path);
-			}
-		}
-	}
-);
+    }
+  }
+}
+)
 
-ipcMain.on(
-	ElectronEvents.DownLoadAndInstallLib,
-	(event: Electron.IpcMainEvent, data: { boardName: string; path: string }) => {
-		if (pegApp) {
-			pegApp.DownloadAndInstallLib(data.boardName, data.path);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.DownloadAndInstallLib(data.boardName, data.path);
-			}
-		}
-	}
-);
+ipcMain.on(ElectronEvents.SaveSettings, (event: Electron.IpcMainEvent, file: string,) => {
+  if (pegApp) {
+    pegApp.SaveSetting(event, file, ElectronEvents.SaveSettings)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.SaveSetting(event, file, ElectronEvents.SaveSettings)
 
-ipcMain.on(
-	ElectronEvents.SaveOled,
-	(
-		event: Electron.IpcMainEvent,
-		data: { fileData: number[][]; fileNumber: number | string }
-	) => {
-		if (pegApp) {
-			pegApp.oledSave(event, data);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.oledSave(event, data);
-			}
-		}
-	}
-);
-ipcMain.on(
-	ElectronEvents.ReadOled,
-	(event: Electron.IpcMainEvent, fileNumber: number) => {
-		if (pegApp) {
-			pegApp.oledread(event, fileNumber);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.oledread(event, fileNumber);
-			}
-		}
-	}
-);
+    }
+  }
+}
+)
+
+ipcMain.on(ElectronEvents.SaveCustomCodes, (event: Electron.IpcMainEvent, file: string,) => {
+  console.log("save file")
+  if (pegApp) {
+    pegApp.SaveSetting(event, file, ElectronEvents.SaveCustomCodes)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.SaveSetting(event, file, ElectronEvents.SaveCustomCodes)
+
+    }
+  }
+}
+)
+
+
+ipcMain.on(ElectronEvents.Savefile, (event: Electron.IpcMainEvent, data: { fileData: string, path: string[] }) => {
+  if (pegApp) {
+    pegApp.writeFile(event, data)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.writeFile(event, data)
+
+    }
+  }
+}
+)
+
+ipcMain.on(ElectronEvents.InstallKmk, (event: Electron.IpcMainEvent, path: string) => {
+  if (pegApp) {
+    pegApp.InstallKmk(path)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.InstallKmk(path)
+
+    }
+  }
+}
+)
+
+ipcMain.on(ElectronEvents.DownLoadAndInstallLib, (event: Electron.IpcMainEvent, data: { boardName: string, path: string, }) => {
+  if (pegApp) {
+    pegApp.DownloadAndInstallLib(data.boardName, data.path)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.DownloadAndInstallLib(data.boardName, data.path)
+    }
+  }
+}
+)
+
+ipcMain.on(ElectronEvents.SaveOled, (event: Electron.IpcMainEvent, data: { fileData: number[][], fileNumber: number | string }) => {
+  if (pegApp) {
+    pegApp.oledSave(event, data)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.oledSave(event, data)
+
+    }
+  }
+}
+)
+ipcMain.on(ElectronEvents.ReadOled, (event: Electron.IpcMainEvent, fileNumber: number) => {
+  if (pegApp) {
+    pegApp.oledread(event, fileNumber)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.oledread(event, fileNumber)
+
+    }
+  }
+}
+)
 
 ipcMain.on(ElectronEvents.DownLoadKmk, (event: Electron.IpcMainEvent) => {
-	if (pegApp) {
-		pegApp.DownloadKmk();
-	} else {
-		if (mainWindow !== null) {
-			pegApp = AppManager.getInstance(mainWindow);
-			pegApp.DownloadKmk();
-		}
-	}
-});
+  if (pegApp) {
+    pegApp.DownloadKmk()
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.DownloadKmk()
 
-ipcMain.on(
-	ElectronEvents.SetProPlan,
-	(event: Electron.IpcMainEvent, id: string) => {
-		if (pegApp) {
-			pegApp.saveProPlan(event, id);
-		} else {
-			if (mainWindow !== null) {
-				pegApp = AppManager.getInstance(mainWindow);
-				pegApp.saveProPlan(event, id);
-			}
-		}
-	}
-);
+    }
+  }
+}
+)
 
-ipcMain.on(
-	ElectronEvents.FilePicker,
-	async (event: Electron.IpcMainEvent, file: string) => {
-		if (mainWindow !== null) {
-			const drivePath = await dialog.showOpenDialogSync(mainWindow, {
-				properties: ["openFile", "openDirectory"],
-			});
-			event.reply(
-				ElectronEvents.FilePickerClose,
-				drivePath ? drivePath[0] : ""
-			);
-		}
-	}
-);
+
+ipcMain.on(ElectronEvents.SetProPlan, (event: Electron.IpcMainEvent, id: string) => {
+  if (pegApp) {
+    pegApp.saveProPlan(event, id)
+  } else {
+    if (mainWindow !== null) {
+      pegApp = AppManager.getInstance(mainWindow)
+      pegApp.saveProPlan(event, id)
+
+    }
+  }
+}
+)
+
+
+
+ipcMain.on(ElectronEvents.FilePicker, async (event: Electron.IpcMainEvent, file: string,) => {
+  if (mainWindow !== null) {
+    const drivePath = await dialog.showOpenDialogSync(mainWindow, {
+      properties: ['openFile', 'openDirectory']
+    })
+    event.reply(ElectronEvents.FilePickerClose, drivePath ? drivePath[0] : '')
+  }
+}
+)
+
 
 ipcMain.on(ElectronEvents.WindowClose, (event: Electron.IpcMainEvent) => {
-	if (mainWindow !== null) {
-		mainWindow.close();
-	}
-});
+  if (mainWindow !== null) {
+    mainWindow.close()
+  }
+}
+)
+ipcMain.on(ElectronEvents.WindowFullScreen, (event: Electron.IpcMainEvent) => {
+  if (mainWindow !== null) {
+    mainWindow.fullScreen = !mainWindow.fullScreen
+  }
+}
+)
+ipcMain.on(ElectronEvents.WindowMinimize, (event: Electron.IpcMainEvent) => {
+  if (mainWindow !== null) {
+    mainWindow.minimize()
+  }
+}
+)
 ipcMain.on(ElectronEvents.OpenFile, (event: Electron.IpcMainEvent) => {
 	shell.openPath(pegApp?.diskManager.getDrivePath() + "/main.py");
 });
-ipcMain.on(ElectronEvents.WindowFullScreen, (event: Electron.IpcMainEvent) => {
-	if (mainWindow !== null) {
-		mainWindow.fullScreen = !mainWindow.fullScreen;
-	}
-});
-ipcMain.on(ElectronEvents.WindowMinimize, (event: Electron.IpcMainEvent) => {
-	if (mainWindow !== null) {
-		mainWindow.minimize();
-	}
-});
+
+
 
 app.whenReady().then(() => {
-	createWindow();
-	app.on("activate", () => {
-		if (BrowserWindow.getAllWindows().length === 0) {
-			createWindow();
-		}
-	});
-});
+  createWindow()
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow()
+    }
+  });
+
+
+})

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { ElectronEvents, FileName } from '../src/types/types';
 let mainWindow: BrowserWindow | null = null;
 let pegApp: AppManager | null = null;
+const fs = require("fs")
 const createWindow = async () => {
 
   mainWindow = new BrowserWindow({
@@ -295,7 +296,21 @@ ipcMain.on(ElectronEvents.WindowMinimize, (event: Electron.IpcMainEvent) => {
 }
 )
 ipcMain.on(ElectronEvents.OpenFile, (event: Electron.IpcMainEvent) => {
-	shell.openPath(pegApp?.diskManager.getDrivePath() + "/main.py");
+  if(pegApp){
+    //create file 
+    pegApp.diskManager.createTempKeymap()
+        //  open file
+    shell.openPath(path.join(app.getPath("temp"), "/tempKeymap.py"));
+    // wait for changes
+    const watcher = fs.watchFile(path.join(app.getPath("temp"), "/tempKeymap.py"), (currentState:any, previousState:any) =>{
+      if (previousState.mtimeMs!== 0){
+        console.log("second Change")
+        //call diskmanager save file
+        pegApp!.diskManager.saveFile(fs.readFileSync(path.join(app.getPath("temp"), "/tempKeymap.py")))
+      }
+      console.log(previousState.mtimeMs)
+    });
+  }
 });
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Peg",
-  "version": "0.8.81",
+  "version": "0.9.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "Peg",
-      "version": "0.8.81",
+      "version": "0.9.8",
       "hasInstallScript": true,
       "dependencies": {
         "@thisbeyond/solid-dnd": "^0.4.1",

--- a/src/logic/clientManager.ts
+++ b/src/logic/clientManager.ts
@@ -1,369 +1,322 @@
-import {
-	ElectronEvents,
-	KeyCode,
-	ModalDefault,
-	SplitFlashStage,
-	ToastLevel,
-} from "../types/types";
+import { ElectronEvents, KeyCode, ModalDefault, SplitFlashStage, ToastLevel } from "../types/types";
 import { Color } from "./color";
 import { isKeyCode } from "./helpers";
 import { KeyMap } from "./keymapManager";
 import { ProgramSettings } from "./programSettings";
 import { Subscribable } from "./subscribable";
-import axios from "axios";
+import axios from "axios"
 import { Modal } from "./modal";
 import { Toast } from "./toast";
 
 export class ClientManager extends Subscribable {
-	private static instance: ClientManager;
-	keymap: KeyMap;
-	waitingLayer: number | undefined = undefined;
-	waitingIndex: number | undefined = undefined;
-	waitingKey: boolean = false;
-	waitingIsEncoder: boolean = false;
-	waitingIsLed: boolean = false;
-	scaning: boolean = false;
-	programSettings: ProgramSettings;
-	changesMade: boolean = false;
-	ledChangesMadeAndIsSplit: boolean = false;
-	platform: string;
-	isOnLine: boolean = true;
-	dontOverRide: boolean = false;
-	currentLayer: number = 0;
-	SplitFlashDisplayState: SplitFlashStage = SplitFlashStage.MainSide;
-	canUnplug: boolean = true;
-	lostConnectionToBoard: boolean = false;
-	kmkInstalled: boolean = true;
-	libInstalled: boolean = true;
+    private static instance: ClientManager;
+    keymap: KeyMap
+    waitingLayer: number | undefined = undefined;
+    waitingIndex: number | undefined = undefined;
+    waitingKey: boolean = false;
+    waitingIsEncoder: boolean = false
+    waitingIsLed: boolean = false;
+    scaning: boolean = false
+    programSettings: ProgramSettings
+    changesMade: boolean = false;
+    ledChangesMadeAndIsSplit: boolean = false;
+    platform: string
+    isOnLine: boolean = true
+    dontOverRide: boolean = false
+    currentLayer: number = 0
+    SplitFlashDisplayState: SplitFlashStage = SplitFlashStage.MainSide
+    canUnplug: boolean = true
+    lostConnectionToBoard: boolean = false;
+    kmkInstalled: boolean = true
+    libInstalled: boolean = true;
 
-	private constructor() {
-		super();
-		//@ts-ignore
-		this.platform = window.electron.platform;
-		this.keymap = KeyMap.getInstance();
+    private constructor() {
+        super();
+        //@ts-ignore
+        this.platform = window.electron.platform;
+        this.keymap = KeyMap.getInstance()
 
-		this.programSettings = ProgramSettings.getInstance();
-		this.lessonToEvent(ElectronEvents.UpdateLayout, (args: string) => {
-			this.scaning = false;
-			this.updateSubScribers();
-			this.keymap.ParceLayout(args);
-			if (this.SplitFlashDisplayState !== SplitFlashStage.MainSide) {
-				this.ChangeSplitFlashDisplayState(SplitFlashStage.OffSide);
-			}
-		});
-		this.lessonToEvent(ElectronEvents.UpdateKeyMap, (args: string) => {
-			this.scaning = false;
-			if (!this.dontOverRide) {
-				this.keymap.StringToKeymap(args);
-			} else {
-				this.keymap.oled = undefined;
-				const ledBackup = [...this.keymap.ledMap];
-				const keymapBackup = [...this.keymap.keymap];
-				this.keymap.StringToKeymap(args);
-				this.keymap.ledMap = ledBackup;
-				this.keymap.keymap = keymapBackup;
-				this.ChangeSplitFlashDisplayState(SplitFlashStage.OffSide);
-				Toast.Debug(`not over riding keymap saving ledMap and keymap `);
-			}
-			this.updateSubScribers();
-		});
-		this.lessonToEvent(ElectronEvents.ScanAgain, (_args: string) => {
-			this.scaning = true;
-			setTimeout(() => {
-				this.updateSubScribers();
-			}, 2000);
-		});
-		this.lessonToEvent(
-			ElectronEvents.UpdateOled,
-			(args: { oledData: number[][]; fileNumber: number | string }) => {
-				this.keymap.oled?.RecievImgDataFromBackEnd(
-					args.oledData,
-					Number(args.fileNumber)
-				);
-			}
-		);
-		this.lessonToEvent(ElectronEvents.ReadSettings, (settingsStr) => {
-			try {
-				const tempSettings = JSON.parse(settingsStr);
-				Object.keys(this.programSettings).forEach((key: string) => {
-					if (key !== "_apiUrl") {
-						const realKey = key.substring(1);
-						//@ts-ignore
-						this.programSettings[realKey] = tempSettings[realKey];
-					}
-				});
-			} catch (error) {
-				Toast.Debug(`Error in ReadSettings ${JSON.stringify(error)} `);
-				console.log("error", error);
-			}
-		});
+        this.programSettings = ProgramSettings.getInstance()
+        this.lessonToEvent(ElectronEvents.UpdateLayout, (args: string) => {
+            this.scaning = false
+            this.updateSubScribers()
+            this.keymap.ParceLayout(args)
+            if (this.SplitFlashDisplayState !== SplitFlashStage.MainSide) {
+                this.ChangeSplitFlashDisplayState(SplitFlashStage.OffSide)
+            }
 
-		this.lessonToEvent(ElectronEvents.ReadCustomCodes, (customCodesStr) => {
-			try {
-				const tempCustomCodes = JSON.parse(customCodesStr);
-				const customKeycodes = tempCustomCodes as KeyCode[];
-				this.keymap.codes.customCodes = new Map(
-					customKeycodes.map((i) => [i.code, i])
-				);
-			} catch (error) {
-				Toast.Debug(`Error in ReadCustomCodes ${JSON.stringify(error)} `);
-				console.log("error", error);
-			}
-		});
+        })
+        this.lessonToEvent(ElectronEvents.UpdateKeyMap, (args: string) => {
+            this.scaning = false
+            if (!this.dontOverRide) {
+                this.keymap.StringToKeymap(args)
+            } else {
+                this.keymap.oled = undefined
+                const ledBackup = [...this.keymap.ledMap]
+                const keymapBackup = [...this.keymap.keymap]
+                this.keymap.StringToKeymap(args)
+                this.keymap.ledMap = ledBackup
+                this.keymap.keymap = keymapBackup
+                this.ChangeSplitFlashDisplayState(SplitFlashStage.OffSide)
+                Toast.Debug(`not over riding keymap saving ledMap and keymap `)
+            }
+            this.updateSubScribers()
+        })
+        this.lessonToEvent(ElectronEvents.ScanAgain, (_args: string) => {
+            this.scaning = true
+            setTimeout(() => {
+                this.updateSubScribers()
+            }, 2000);
+        })
+        this.lessonToEvent(ElectronEvents.UpdateOled, (args: { oledData: number[][], fileNumber: number | string }) => {
+            this.keymap.oled?.RecievImgDataFromBackEnd(args.oledData, Number(args.fileNumber))
+        })
+        this.lessonToEvent(ElectronEvents.ReadSettings, (settingsStr) => {
+            try {
+                const tempSettings = JSON.parse(settingsStr)
+                Object.keys(this.programSettings).forEach((key: string) => {
+                    if (key !== "_apiUrl") {
+                        const realKey = key.substring(1)
+                        //@ts-ignore
+                        this.programSettings[realKey] = tempSettings[realKey]
+                    }
+                });
+            } catch (error) {
+                Toast.Debug(`Error in ReadSettings ${JSON.stringify(error)} `)
+                console.log("error", error)
+            }
 
-		this.lessonToEvent(ElectronEvents.MapSaved, () => {
-			Toast.Success("keymap saved! You can unplug your keyboard if you want");
-			this.canUnplug = true;
-			this.updateSubScribers();
+        })
 
-			if (this.SplitFlashDisplayState === SplitFlashStage.OffSide) {
-				this.ChangeSplitFlashDisplayState(SplitFlashStage.Finished);
-			}
-		});
+        this.lessonToEvent(ElectronEvents.ReadCustomCodes, (customCodesStr) => {
+            try {
+                const tempCustomCodes = JSON.parse(customCodesStr)
+                const customKeycodes = tempCustomCodes as KeyCode[]
+                this.keymap.codes.customCodes = new Map(customKeycodes.map(i => [i.code, i]));
+            } catch (error) {
+                Toast.Debug(`Error in ReadCustomCodes ${JSON.stringify(error)} `)
+                console.log("error", error)
+            }
+        })
 
-		this.lessonToEvent(ElectronEvents.BoardChange, () => {
-			Toast.Success("Detected New keyboard plugged in");
-		});
+        this.lessonToEvent(ElectronEvents.MapSaved, () => {
+            Toast.Success("keymap saved! You can unplug your keyboard if you want")
+            this.canUnplug = true
+            this.updateSubScribers()
 
-		this.lessonToEvent(
-			ElectronEvents.Toast,
-			(data: { status: ToastLevel; message: string }) => {
-				Toast.getInstance().show(data.message, data.status);
-				if (data.status === ToastLevel.success) {
-					if (
-						!this.kmkInstalled &&
-						data.message.toLowerCase().includes("kmk")
-					) {
-						console.log("kmk installed");
-						this.kmkInstalled = true;
-					}
-					if (
-						!this.libInstalled &&
-						data.message.toLowerCase().includes("lib")
-					) {
-						console.log("lib installed");
-						this.libInstalled = true;
-					}
-					if (!this.canUnplug && this.libInstalled && this.kmkInstalled) {
-						console.log("you good");
-						this.canUnplug = true;
-						this.updateSubScribers();
-					}
-				}
-			}
-		);
-		this.lessonToEvent(ElectronEvents.LostConnectionToBoard, () => {
-			if (!this.lostConnectionToBoard) {
-				Toast.Warn(
-					`Peg lost connection to ${this.keymap.keyLayout.features.name}`
-				);
-				this.lostConnectionToBoard = true;
-				setTimeout(() => {
-					this.lostConnectionToBoard = false;
-				}, 10000);
-			}
-		});
-		this.lessonToEvent(ElectronEvents.IsProPlan, () => {
-			this.programSettings.PPP = true;
-		});
+            if (this.SplitFlashDisplayState === SplitFlashStage.OffSide) {
+                this.ChangeSplitFlashDisplayState(SplitFlashStage.Finished)
+            }
+        })
 
-		this.programSettings.Subscribe(() => {
-			this.sendToBackend(
-				ElectronEvents.SaveSettings,
-				JSON.stringify({
-					seven: this.programSettings.seven,
-					theme: this.programSettings.theme,
-					tooltips: this.programSettings.tooltips,
-					debug: this.programSettings.debug,
-				})
-			);
-		});
-		setTimeout(() => {
-			///issues/3 removed this
-			// if (!this.scaning && this.keymap.layout === undefined) {
-			//     this.sendToBackend(ElectronEvents.Scan, "")
-			// }
-			this.sendToBackend(ElectronEvents.ClientUp, "");
-		}, 2000);
+        this.lessonToEvent(ElectronEvents.BoardChange, () => {
+            Toast.Success("Detected New keyboard plugged in")
+        })
 
-		this.pingServer();
-	}
-	public ChangeLayer(newLayer: number) {
-		this.currentLayer = newLayer;
-		this.updateSubScribers();
-	}
+        this.lessonToEvent(ElectronEvents.Toast, (data: { status: ToastLevel, message: string }) => {
+            Toast.getInstance().show(data.message, data.status)
+            if (data.status === ToastLevel.success) {
+                if (!this.kmkInstalled && data.message.toLowerCase().includes("kmk")) {
+                    console.log("kmk installed")
+                    this.kmkInstalled = true
+                }
+                if (!this.libInstalled && data.message.toLowerCase().includes("lib")) {
+                    console.log("lib installed")
+                    this.libInstalled = true
+                }
+                if (!this.canUnplug && this.libInstalled && this.kmkInstalled) {
+                    console.log("you good")
+                    this.canUnplug = true
+                    this.updateSubScribers()
+                }
+            }
 
-	public static getInstance(): ClientManager {
-		if (!ClientManager.instance) {
-			ClientManager.instance = new ClientManager();
-		}
-		return ClientManager.instance;
-	}
-	public TellThemToUpdate() {
-		this.updateSubScribers();
-	}
+        })
+        this.lessonToEvent(ElectronEvents.LostConnectionToBoard, () => {
+            if (!this.lostConnectionToBoard) {
+                Toast.Warn(`Peg lost connection to ${this.keymap.keyLayout.features.name}`)
+                this.lostConnectionToBoard = true
+                setTimeout(() => {
+                    this.lostConnectionToBoard = false
+                }, 10000);
+            }
+        })
+        this.lessonToEvent(ElectronEvents.IsProPlan, () => {
+            this.programSettings.PPP = true
+        })
 
-	public NoticeThatKeyIsWaiting(
-		index: number,
-		isLed: boolean,
-		isEncoder: boolean
-	) {
-		this.waitingIndex = index;
-		this.waitingLayer = this.currentLayer;
-		this.waitingIsLed = isLed;
-		this.waitingIsEncoder = isEncoder;
-		this.waitingKey = true;
-		this.updateSubScribers();
-	}
+        this.programSettings.Subscribe(() => {
+            this.sendToBackend(ElectronEvents.SaveSettings,
+                JSON.stringify({
+                    seven: this.programSettings.seven,
+                    theme: this.programSettings.theme,
+                    tooltips: this.programSettings.tooltips,
+                    debug: this.programSettings.debug
+                }))
+        })
+        setTimeout(() => {
+            ///issues/3 removed this
+            // if (!this.scaning && this.keymap.layout === undefined) {
+            //     this.sendToBackend(ElectronEvents.Scan, "")
+            // }
+            this.sendToBackend(ElectronEvents.ClientUp, "")
+        }, 2000);
 
-	public NoticeToUpdateKey(newKeyCode: KeyCode | Color) {
-		if (
-			this.waitingKey &&
-			this.waitingIndex !== undefined &&
-			this.waitingLayer !== undefined
-		) {
-			this.changesMade = true;
-			if (!this.waitingIsLed && "code" in newKeyCode) {
-				this.keymap.ChangeKey(
-					this.waitingLayer,
-					this.waitingIndex,
-					newKeyCode,
-					this.waitingIsEncoder
-				);
-			} else if ("r" in newKeyCode) {
-				// console.log("I must be a color", newKeyCode)
-				this.keymap.ChangeLed(this.waitingLayer, this.waitingIndex, newKeyCode);
-				if (this.keymap.keyLayout.features.split) {
-					this.ledChangesMadeAndIsSplit = true;
-				}
-			}
-			this.waitingIndex = undefined;
-			this.waitingLayer = undefined;
-			this.waitingIsLed = false;
-			this.waitingKey = false;
-			this.updateSubScribers();
-		}
-	}
-	public ForceKeyChange(
-		layer: number,
-		pos: number,
-		newKey: KeyCode | Color,
-		isEncoder: boolean
-	) {
-		if (isKeyCode(newKey)) {
-			this.keymap.ChangeKey(layer, pos, newKey, isEncoder);
-		} else {
-			this.keymap.ChangeLed(layer, pos, newKey);
-			if (this.keymap.keyLayout.features.split) {
-				this.ledChangesMadeAndIsSplit = true;
-			}
-		}
-		this.changesMade = true;
-		this.updateSubScribers();
-		Toast.Debug(
-			`forcing all key change:  ${JSON.stringify({
-				layer,
-				pos,
-				newKey,
-				isEncoder,
-			})} `
-		);
-	}
-	public ForceAllLedChange(newColor: Color) {
-		this.keymap.ChangeAllLeds(newColor);
-		if (this.keymap.keyLayout.features.split) {
-			this.ledChangesMadeAndIsSplit = true;
-		}
-		this.changesMade = true;
-		this.updateSubScribers();
-		Toast.Debug(`forcing all leds to new color:  ${JSON.stringify(newColor)} `);
-	}
-	public RemoveCodeBlock(index: number) {
-		this.keymap.RemoveCodeBlock(index);
-		this.NoticeAChangeWasMade();
-	}
+        this.pingServer()
 
-	public NoticeAChangeWasMade() {
-		this.changesMade = true;
-		this.updateSubScribers();
-	}
 
-	public SaveMap() {
-		Toast.Debug(`wanting to save map`);
-		if (this.changesMade) {
-			Toast.Info(`Saving Changes Dont Unplug Your Keyboard`);
-			this.canUnplug = false;
-			this.sendToBackend(ElectronEvents.SaveMap, this.keymap.toString());
-			this.changesMade = false;
-			Toast.Debug(`saving map`);
-		}
-		if (this.ledChangesMadeAndIsSplit) {
-			Toast.Info(`Saving Changes Dont Unplug Your Keyboard`);
-			const modal = Modal.getInstance();
-			modal.OpenDefault(
-				"Split LED Flashing",
-				false,
-				ModalDefault.SplitFlashManager
-			);
-			this.dontOverRide = true;
-			Toast.Debug(`handling split led changes `);
-		}
-	}
-	public ChangeSplitFlashDisplayState = (newDisplayState: SplitFlashStage) => {
-		this.SplitFlashDisplayState = newDisplayState;
-		switch (newDisplayState) {
-			case SplitFlashStage.Unplugged:
-				this.sendToBackend(ElectronEvents.FreshDriveScan, "");
-				Toast.Debug(`SplitFlashStage.Unplugged`);
-				break;
-			case SplitFlashStage.OffSide:
-				if (this.keymap.keyLayout.features.rightSide) {
-					this.changesMade = true;
-					setTimeout(() => {
-						this.SaveMap();
-					}, 1000);
+    }
+    public ChangeLayer(newLayer: number) {
+        this.currentLayer = newLayer
+        this.updateSubScribers()
 
-					this.ledChangesMadeAndIsSplit = false;
-					Toast.Debug(`SplitFlashStage.OffSide`);
-				}
-			default:
-				break;
-		}
-		this.updateSubScribers();
-	};
+    }
 
-	async pingServer() {
-		axios
-			.get(`${this.programSettings.apiUrl}hp-check`)
-			.then(() => {
-				this.isOnLine = true;
-				Toast.Debug(`server on line`);
-			})
-			.catch(() => {
-				this.isOnLine = false;
-				this.updateSubScribers();
-				Toast.Debug(`error from server hp-check`);
-			});
-	}
+    public static getInstance(): ClientManager {
+        if (!ClientManager.instance) {
+            ClientManager.instance = new ClientManager();
+        }
+        return ClientManager.instance;
+    }
+    public TellThemToUpdate() {
+        this.updateSubScribers()
+    }
 
-	sendToBackend(key: ElectronEvents, data: any) {
-		//@ts-ignore
-		window.electron.ipcRenderer.send(key, data);
-	}
-	lessonToEvent(key: ElectronEvents, callBack: (args: any) => void) {
-		//@ts-ignore
-		window.electron.ipcRenderer.on(key, (arg: any) => {
-			try {
-				callBack(arg);
-			} catch (error) {
-				Toast.Error(`error in handling event:${key}`);
+    public NoticeThatKeyIsWaiting(index: number, isLed: boolean, isEncoder: boolean) {
+        this.waitingIndex = index;
+        this.waitingLayer = this.currentLayer;
+        this.waitingIsLed = isLed;
+        this.waitingIsEncoder = isEncoder
+        this.waitingKey = true;
+        this.updateSubScribers()
+    }
 
-				console.log(
-					"error in handling event from backend",
-					`event:${key}`,
-					error
-				);
-			}
-		});
-	}
+    public NoticeToUpdateKey(newKeyCode: KeyCode | Color) {
+        if (this.waitingKey && this.waitingIndex !== undefined && this.waitingLayer !== undefined) {
+            this.changesMade = true
+            if (!this.waitingIsLed && "code" in newKeyCode) {
+                this.keymap.ChangeKey(this.waitingLayer, this.waitingIndex, newKeyCode, this.waitingIsEncoder);
+
+            }
+            else if ("r" in newKeyCode) {
+                // console.log("I must be a color", newKeyCode)
+                this.keymap.ChangeLed(this.waitingLayer, this.waitingIndex, newKeyCode)
+                if (this.keymap.keyLayout.features.split) {
+                    this.ledChangesMadeAndIsSplit = true
+                }
+            }
+            this.waitingIndex = undefined;
+            this.waitingLayer = undefined;
+            this.waitingIsLed = false;
+            this.waitingKey = false;
+            this.updateSubScribers()
+
+        }
+    }
+    public ForceKeyChange(layer: number, pos: number, newKey: KeyCode | Color, isEncoder: boolean) {
+        if (isKeyCode(newKey)) {
+            this.keymap.ChangeKey(layer, pos, newKey, isEncoder);
+        } else {
+            this.keymap.ChangeLed(layer, pos, newKey);
+            if (this.keymap.keyLayout.features.split) {
+                this.ledChangesMadeAndIsSplit = true
+            }
+        }
+        this.changesMade = true
+        this.updateSubScribers()
+        Toast.Debug(`forcing all key change:  ${JSON.stringify({ layer, pos, newKey, isEncoder })} `)
+
+    }
+    public ForceAllLedChange(newColor: Color) {
+        this.keymap.ChangeAllLeds(newColor)
+        if (this.keymap.keyLayout.features.split) {
+            this.ledChangesMadeAndIsSplit = true
+        }
+        this.changesMade = true
+        this.updateSubScribers()
+        Toast.Debug(`forcing all leds to new color:  ${JSON.stringify(newColor)} `)
+
+    }
+    public RemoveCodeBlock(index: number) {
+        this.keymap.RemoveCodeBlock(index)
+        this.NoticeAChangeWasMade()
+    }
+
+    public NoticeAChangeWasMade() {
+        this.changesMade = true
+        this.updateSubScribers()
+    }
+
+    public SaveMap() {
+        Toast.Debug(`wanting to save map`)
+        if (this.changesMade) {
+            Toast.Info(`Saving Changes Dont Unplug Your Keyboard`)
+            this.canUnplug = false
+            this.sendToBackend(ElectronEvents.SaveMap, this.keymap.toString())
+            this.changesMade = false
+            Toast.Debug(`saving map`)
+        }
+        if (this.ledChangesMadeAndIsSplit) {
+            Toast.Info(`Saving Changes Dont Unplug Your Keyboard`)
+            const modal = Modal.getInstance()
+            modal.OpenDefault("Split LED Flashing", false, ModalDefault.SplitFlashManager)
+            this.dontOverRide = true
+            Toast.Debug(`handling split led changes `)
+        }
+
+    }
+    public ChangeSplitFlashDisplayState = (newDisplayState: SplitFlashStage) => {
+        this.SplitFlashDisplayState = newDisplayState
+        switch (newDisplayState) {
+            case SplitFlashStage.Unplugged:
+                this.sendToBackend(ElectronEvents.FreshDriveScan, "")
+                Toast.Debug(`SplitFlashStage.Unplugged`)
+                break;
+            case SplitFlashStage.OffSide:
+                if (this.keymap.keyLayout.features.rightSide) {
+                    this.changesMade = true
+                    setTimeout(() => {
+                        this.SaveMap()
+                    }, 1000);
+
+                    this.ledChangesMadeAndIsSplit = false
+                    Toast.Debug(`SplitFlashStage.OffSide`)
+                }
+            default:
+                break;
+        }
+        this.updateSubScribers()
+    }
+
+    async pingServer() {
+        axios.get(`${this.programSettings.apiUrl}hp-check`).then(() => {
+            this.isOnLine = true
+            Toast.Debug(`server on line`)
+        }).catch(() => {
+            this.isOnLine = false
+            this.updateSubScribers()
+            Toast.Debug(`error from server hp-check`)
+
+        })
+    }
+
+    sendToBackend(key: ElectronEvents, data: any) {
+        //@ts-ignore
+        window.electron.ipcRenderer.send(key, data)
+
+    }
+    lessonToEvent(key: ElectronEvents, callBack: (args: any) => void) {
+        //@ts-ignore
+        window.electron.ipcRenderer.on(key, (arg: any) => {
+            try {
+                callBack(arg)
+            } catch (error) {
+                Toast.Error(`error in handling event:${key}`)
+
+                console.log("error in handling event from backend", `event:${key}`, error)
+            }
+
+        })
+    }
+
 }

--- a/src/logic/clientManager.ts
+++ b/src/logic/clientManager.ts
@@ -1,322 +1,369 @@
-import { ElectronEvents, KeyCode, ModalDefault, SplitFlashStage, ToastLevel } from "../types/types";
+import {
+	ElectronEvents,
+	KeyCode,
+	ModalDefault,
+	SplitFlashStage,
+	ToastLevel,
+} from "../types/types";
 import { Color } from "./color";
 import { isKeyCode } from "./helpers";
 import { KeyMap } from "./keymapManager";
 import { ProgramSettings } from "./programSettings";
 import { Subscribable } from "./subscribable";
-import axios from "axios"
+import axios from "axios";
 import { Modal } from "./modal";
 import { Toast } from "./toast";
 
 export class ClientManager extends Subscribable {
-    private static instance: ClientManager;
-    keymap: KeyMap
-    waitingLayer: number | undefined = undefined;
-    waitingIndex: number | undefined = undefined;
-    waitingKey: boolean = false;
-    waitingIsEncoder: boolean = false
-    waitingIsLed: boolean = false;
-    scaning: boolean = false
-    programSettings: ProgramSettings
-    changesMade: boolean = false;
-    ledChangesMadeAndIsSplit: boolean = false;
-    platform: string
-    isOnLine: boolean = true
-    dontOverRide: boolean = false
-    currentLayer: number = 0
-    SplitFlashDisplayState: SplitFlashStage = SplitFlashStage.MainSide
-    canUnplug: boolean = true
-    lostConnectionToBoard: boolean = false;
-    kmkInstalled: boolean = true
-    libInstalled: boolean = true;
+	private static instance: ClientManager;
+	keymap: KeyMap;
+	waitingLayer: number | undefined = undefined;
+	waitingIndex: number | undefined = undefined;
+	waitingKey: boolean = false;
+	waitingIsEncoder: boolean = false;
+	waitingIsLed: boolean = false;
+	scaning: boolean = false;
+	programSettings: ProgramSettings;
+	changesMade: boolean = false;
+	ledChangesMadeAndIsSplit: boolean = false;
+	platform: string;
+	isOnLine: boolean = true;
+	dontOverRide: boolean = false;
+	currentLayer: number = 0;
+	SplitFlashDisplayState: SplitFlashStage = SplitFlashStage.MainSide;
+	canUnplug: boolean = true;
+	lostConnectionToBoard: boolean = false;
+	kmkInstalled: boolean = true;
+	libInstalled: boolean = true;
 
-    private constructor() {
-        super();
-        //@ts-ignore
-        this.platform = window.electron.platform;
-        this.keymap = KeyMap.getInstance()
+	private constructor() {
+		super();
+		//@ts-ignore
+		this.platform = window.electron.platform;
+		this.keymap = KeyMap.getInstance();
 
-        this.programSettings = ProgramSettings.getInstance()
-        this.lessonToEvent(ElectronEvents.UpdateLayout, (args: string) => {
-            this.scaning = false
-            this.updateSubScribers()
-            this.keymap.ParceLayout(args)
-            if (this.SplitFlashDisplayState !== SplitFlashStage.MainSide) {
-                this.ChangeSplitFlashDisplayState(SplitFlashStage.OffSide)
-            }
+		this.programSettings = ProgramSettings.getInstance();
+		this.lessonToEvent(ElectronEvents.UpdateLayout, (args: string) => {
+			this.scaning = false;
+			this.updateSubScribers();
+			this.keymap.ParceLayout(args);
+			if (this.SplitFlashDisplayState !== SplitFlashStage.MainSide) {
+				this.ChangeSplitFlashDisplayState(SplitFlashStage.OffSide);
+			}
+		});
+		this.lessonToEvent(ElectronEvents.UpdateKeyMap, (args: string) => {
+			this.scaning = false;
+			if (!this.dontOverRide) {
+				this.keymap.StringToKeymap(args);
+			} else {
+				this.keymap.oled = undefined;
+				const ledBackup = [...this.keymap.ledMap];
+				const keymapBackup = [...this.keymap.keymap];
+				this.keymap.StringToKeymap(args);
+				this.keymap.ledMap = ledBackup;
+				this.keymap.keymap = keymapBackup;
+				this.ChangeSplitFlashDisplayState(SplitFlashStage.OffSide);
+				Toast.Debug(`not over riding keymap saving ledMap and keymap `);
+			}
+			this.updateSubScribers();
+		});
+		this.lessonToEvent(ElectronEvents.ScanAgain, (_args: string) => {
+			this.scaning = true;
+			setTimeout(() => {
+				this.updateSubScribers();
+			}, 2000);
+		});
+		this.lessonToEvent(
+			ElectronEvents.UpdateOled,
+			(args: { oledData: number[][]; fileNumber: number | string }) => {
+				this.keymap.oled?.RecievImgDataFromBackEnd(
+					args.oledData,
+					Number(args.fileNumber)
+				);
+			}
+		);
+		this.lessonToEvent(ElectronEvents.ReadSettings, (settingsStr) => {
+			try {
+				const tempSettings = JSON.parse(settingsStr);
+				Object.keys(this.programSettings).forEach((key: string) => {
+					if (key !== "_apiUrl") {
+						const realKey = key.substring(1);
+						//@ts-ignore
+						this.programSettings[realKey] = tempSettings[realKey];
+					}
+				});
+			} catch (error) {
+				Toast.Debug(`Error in ReadSettings ${JSON.stringify(error)} `);
+				console.log("error", error);
+			}
+		});
 
-        })
-        this.lessonToEvent(ElectronEvents.UpdateKeyMap, (args: string) => {
-            this.scaning = false
-            if (!this.dontOverRide) {
-                this.keymap.StringToKeymap(args)
-            } else {
-                this.keymap.oled = undefined
-                const ledBackup = [...this.keymap.ledMap]
-                const keymapBackup = [...this.keymap.keymap]
-                this.keymap.StringToKeymap(args)
-                this.keymap.ledMap = ledBackup
-                this.keymap.keymap = keymapBackup
-                this.ChangeSplitFlashDisplayState(SplitFlashStage.OffSide)
-                Toast.Debug(`not over riding keymap saving ledMap and keymap `)
-            }
-            this.updateSubScribers()
-        })
-        this.lessonToEvent(ElectronEvents.ScanAgain, (_args: string) => {
-            this.scaning = true
-            setTimeout(() => {
-                this.updateSubScribers()
-            }, 2000);
-        })
-        this.lessonToEvent(ElectronEvents.UpdateOled, (args: { oledData: number[][], fileNumber: number | string }) => {
-            this.keymap.oled?.RecievImgDataFromBackEnd(args.oledData, Number(args.fileNumber))
-        })
-        this.lessonToEvent(ElectronEvents.ReadSettings, (settingsStr) => {
-            try {
-                const tempSettings = JSON.parse(settingsStr)
-                Object.keys(this.programSettings).forEach((key: string) => {
-                    if (key !== "_apiUrl") {
-                        const realKey = key.substring(1)
-                        //@ts-ignore
-                        this.programSettings[realKey] = tempSettings[realKey]
-                    }
-                });
-            } catch (error) {
-                Toast.Debug(`Error in ReadSettings ${JSON.stringify(error)} `)
-                console.log("error", error)
-            }
+		this.lessonToEvent(ElectronEvents.ReadCustomCodes, (customCodesStr) => {
+			try {
+				const tempCustomCodes = JSON.parse(customCodesStr);
+				const customKeycodes = tempCustomCodes as KeyCode[];
+				this.keymap.codes.customCodes = new Map(
+					customKeycodes.map((i) => [i.code, i])
+				);
+			} catch (error) {
+				Toast.Debug(`Error in ReadCustomCodes ${JSON.stringify(error)} `);
+				console.log("error", error);
+			}
+		});
 
-        })
+		this.lessonToEvent(ElectronEvents.MapSaved, () => {
+			Toast.Success("keymap saved! You can unplug your keyboard if you want");
+			this.canUnplug = true;
+			this.updateSubScribers();
 
-        this.lessonToEvent(ElectronEvents.ReadCustomCodes, (customCodesStr) => {
-            try {
-                const tempCustomCodes = JSON.parse(customCodesStr)
-                const customKeycodes = tempCustomCodes as KeyCode[]
-                this.keymap.codes.customCodes = new Map(customKeycodes.map(i => [i.code, i]));
-            } catch (error) {
-                Toast.Debug(`Error in ReadCustomCodes ${JSON.stringify(error)} `)
-                console.log("error", error)
-            }
-        })
+			if (this.SplitFlashDisplayState === SplitFlashStage.OffSide) {
+				this.ChangeSplitFlashDisplayState(SplitFlashStage.Finished);
+			}
+		});
 
-        this.lessonToEvent(ElectronEvents.MapSaved, () => {
-            Toast.Success("keymap saved! You can unplug your keyboard if you want")
-            this.canUnplug = true
-            this.updateSubScribers()
+		this.lessonToEvent(ElectronEvents.BoardChange, () => {
+			Toast.Success("Detected New keyboard plugged in");
+		});
 
-            if (this.SplitFlashDisplayState === SplitFlashStage.OffSide) {
-                this.ChangeSplitFlashDisplayState(SplitFlashStage.Finished)
-            }
-        })
+		this.lessonToEvent(
+			ElectronEvents.Toast,
+			(data: { status: ToastLevel; message: string }) => {
+				Toast.getInstance().show(data.message, data.status);
+				if (data.status === ToastLevel.success) {
+					if (
+						!this.kmkInstalled &&
+						data.message.toLowerCase().includes("kmk")
+					) {
+						console.log("kmk installed");
+						this.kmkInstalled = true;
+					}
+					if (
+						!this.libInstalled &&
+						data.message.toLowerCase().includes("lib")
+					) {
+						console.log("lib installed");
+						this.libInstalled = true;
+					}
+					if (!this.canUnplug && this.libInstalled && this.kmkInstalled) {
+						console.log("you good");
+						this.canUnplug = true;
+						this.updateSubScribers();
+					}
+				}
+			}
+		);
+		this.lessonToEvent(ElectronEvents.LostConnectionToBoard, () => {
+			if (!this.lostConnectionToBoard) {
+				Toast.Warn(
+					`Peg lost connection to ${this.keymap.keyLayout.features.name}`
+				);
+				this.lostConnectionToBoard = true;
+				setTimeout(() => {
+					this.lostConnectionToBoard = false;
+				}, 10000);
+			}
+		});
+		this.lessonToEvent(ElectronEvents.IsProPlan, () => {
+			this.programSettings.PPP = true;
+		});
 
-        this.lessonToEvent(ElectronEvents.BoardChange, () => {
-            Toast.Success("Detected New keyboard plugged in")
-        })
+		this.programSettings.Subscribe(() => {
+			this.sendToBackend(
+				ElectronEvents.SaveSettings,
+				JSON.stringify({
+					seven: this.programSettings.seven,
+					theme: this.programSettings.theme,
+					tooltips: this.programSettings.tooltips,
+					debug: this.programSettings.debug,
+				})
+			);
+		});
+		setTimeout(() => {
+			///issues/3 removed this
+			// if (!this.scaning && this.keymap.layout === undefined) {
+			//     this.sendToBackend(ElectronEvents.Scan, "")
+			// }
+			this.sendToBackend(ElectronEvents.ClientUp, "");
+		}, 2000);
 
-        this.lessonToEvent(ElectronEvents.Toast, (data: { status: ToastLevel, message: string }) => {
-            Toast.getInstance().show(data.message, data.status)
-            if (data.status === ToastLevel.success) {
-                if (!this.kmkInstalled && data.message.toLowerCase().includes("kmk")) {
-                    console.log("kmk installed")
-                    this.kmkInstalled = true
-                }
-                if (!this.libInstalled && data.message.toLowerCase().includes("lib")) {
-                    console.log("lib installed")
-                    this.libInstalled = true
-                }
-                if (!this.canUnplug && this.libInstalled && this.kmkInstalled) {
-                    console.log("you good")
-                    this.canUnplug = true
-                    this.updateSubScribers()
-                }
-            }
+		this.pingServer();
+	}
+	public ChangeLayer(newLayer: number) {
+		this.currentLayer = newLayer;
+		this.updateSubScribers();
+	}
 
-        })
-        this.lessonToEvent(ElectronEvents.LostConnectionToBoard, () => {
-            if (!this.lostConnectionToBoard) {
-                Toast.Warn(`Peg lost connection to ${this.keymap.keyLayout.features.name}`)
-                this.lostConnectionToBoard = true
-                setTimeout(() => {
-                    this.lostConnectionToBoard = false
-                }, 10000);
-            }
-        })
-        this.lessonToEvent(ElectronEvents.IsProPlan, () => {
-            this.programSettings.PPP = true
-        })
+	public static getInstance(): ClientManager {
+		if (!ClientManager.instance) {
+			ClientManager.instance = new ClientManager();
+		}
+		return ClientManager.instance;
+	}
+	public TellThemToUpdate() {
+		this.updateSubScribers();
+	}
 
-        this.programSettings.Subscribe(() => {
-            this.sendToBackend(ElectronEvents.SaveSettings,
-                JSON.stringify({
-                    seven: this.programSettings.seven,
-                    theme: this.programSettings.theme,
-                    tooltips: this.programSettings.tooltips,
-                    debug: this.programSettings.debug
-                }))
-        })
-        setTimeout(() => {
-            ///issues/3 removed this
-            // if (!this.scaning && this.keymap.layout === undefined) {
-            //     this.sendToBackend(ElectronEvents.Scan, "")
-            // }
-            this.sendToBackend(ElectronEvents.ClientUp, "")
-        }, 2000);
+	public NoticeThatKeyIsWaiting(
+		index: number,
+		isLed: boolean,
+		isEncoder: boolean
+	) {
+		this.waitingIndex = index;
+		this.waitingLayer = this.currentLayer;
+		this.waitingIsLed = isLed;
+		this.waitingIsEncoder = isEncoder;
+		this.waitingKey = true;
+		this.updateSubScribers();
+	}
 
-        this.pingServer()
+	public NoticeToUpdateKey(newKeyCode: KeyCode | Color) {
+		if (
+			this.waitingKey &&
+			this.waitingIndex !== undefined &&
+			this.waitingLayer !== undefined
+		) {
+			this.changesMade = true;
+			if (!this.waitingIsLed && "code" in newKeyCode) {
+				this.keymap.ChangeKey(
+					this.waitingLayer,
+					this.waitingIndex,
+					newKeyCode,
+					this.waitingIsEncoder
+				);
+			} else if ("r" in newKeyCode) {
+				// console.log("I must be a color", newKeyCode)
+				this.keymap.ChangeLed(this.waitingLayer, this.waitingIndex, newKeyCode);
+				if (this.keymap.keyLayout.features.split) {
+					this.ledChangesMadeAndIsSplit = true;
+				}
+			}
+			this.waitingIndex = undefined;
+			this.waitingLayer = undefined;
+			this.waitingIsLed = false;
+			this.waitingKey = false;
+			this.updateSubScribers();
+		}
+	}
+	public ForceKeyChange(
+		layer: number,
+		pos: number,
+		newKey: KeyCode | Color,
+		isEncoder: boolean
+	) {
+		if (isKeyCode(newKey)) {
+			this.keymap.ChangeKey(layer, pos, newKey, isEncoder);
+		} else {
+			this.keymap.ChangeLed(layer, pos, newKey);
+			if (this.keymap.keyLayout.features.split) {
+				this.ledChangesMadeAndIsSplit = true;
+			}
+		}
+		this.changesMade = true;
+		this.updateSubScribers();
+		Toast.Debug(
+			`forcing all key change:  ${JSON.stringify({
+				layer,
+				pos,
+				newKey,
+				isEncoder,
+			})} `
+		);
+	}
+	public ForceAllLedChange(newColor: Color) {
+		this.keymap.ChangeAllLeds(newColor);
+		if (this.keymap.keyLayout.features.split) {
+			this.ledChangesMadeAndIsSplit = true;
+		}
+		this.changesMade = true;
+		this.updateSubScribers();
+		Toast.Debug(`forcing all leds to new color:  ${JSON.stringify(newColor)} `);
+	}
+	public RemoveCodeBlock(index: number) {
+		this.keymap.RemoveCodeBlock(index);
+		this.NoticeAChangeWasMade();
+	}
 
+	public NoticeAChangeWasMade() {
+		this.changesMade = true;
+		this.updateSubScribers();
+	}
 
-    }
-    public ChangeLayer(newLayer: number) {
-        this.currentLayer = newLayer
-        this.updateSubScribers()
+	public SaveMap() {
+		Toast.Debug(`wanting to save map`);
+		if (this.changesMade) {
+			Toast.Info(`Saving Changes Dont Unplug Your Keyboard`);
+			this.canUnplug = false;
+			this.sendToBackend(ElectronEvents.SaveMap, this.keymap.toString());
+			this.changesMade = false;
+			Toast.Debug(`saving map`);
+		}
+		if (this.ledChangesMadeAndIsSplit) {
+			Toast.Info(`Saving Changes Dont Unplug Your Keyboard`);
+			const modal = Modal.getInstance();
+			modal.OpenDefault(
+				"Split LED Flashing",
+				false,
+				ModalDefault.SplitFlashManager
+			);
+			this.dontOverRide = true;
+			Toast.Debug(`handling split led changes `);
+		}
+	}
+	public ChangeSplitFlashDisplayState = (newDisplayState: SplitFlashStage) => {
+		this.SplitFlashDisplayState = newDisplayState;
+		switch (newDisplayState) {
+			case SplitFlashStage.Unplugged:
+				this.sendToBackend(ElectronEvents.FreshDriveScan, "");
+				Toast.Debug(`SplitFlashStage.Unplugged`);
+				break;
+			case SplitFlashStage.OffSide:
+				if (this.keymap.keyLayout.features.rightSide) {
+					this.changesMade = true;
+					setTimeout(() => {
+						this.SaveMap();
+					}, 1000);
 
-    }
+					this.ledChangesMadeAndIsSplit = false;
+					Toast.Debug(`SplitFlashStage.OffSide`);
+				}
+			default:
+				break;
+		}
+		this.updateSubScribers();
+	};
 
-    public static getInstance(): ClientManager {
-        if (!ClientManager.instance) {
-            ClientManager.instance = new ClientManager();
-        }
-        return ClientManager.instance;
-    }
-    public TellThemToUpdate() {
-        this.updateSubScribers()
-    }
+	async pingServer() {
+		axios
+			.get(`${this.programSettings.apiUrl}hp-check`)
+			.then(() => {
+				this.isOnLine = true;
+				Toast.Debug(`server on line`);
+			})
+			.catch(() => {
+				this.isOnLine = false;
+				this.updateSubScribers();
+				Toast.Debug(`error from server hp-check`);
+			});
+	}
 
-    public NoticeThatKeyIsWaiting(index: number, isLed: boolean, isEncoder: boolean) {
-        this.waitingIndex = index;
-        this.waitingLayer = this.currentLayer;
-        this.waitingIsLed = isLed;
-        this.waitingIsEncoder = isEncoder
-        this.waitingKey = true;
-        this.updateSubScribers()
-    }
+	sendToBackend(key: ElectronEvents, data: any) {
+		//@ts-ignore
+		window.electron.ipcRenderer.send(key, data);
+	}
+	lessonToEvent(key: ElectronEvents, callBack: (args: any) => void) {
+		//@ts-ignore
+		window.electron.ipcRenderer.on(key, (arg: any) => {
+			try {
+				callBack(arg);
+			} catch (error) {
+				Toast.Error(`error in handling event:${key}`);
 
-    public NoticeToUpdateKey(newKeyCode: KeyCode | Color) {
-        if (this.waitingKey && this.waitingIndex !== undefined && this.waitingLayer !== undefined) {
-            this.changesMade = true
-            if (!this.waitingIsLed && "code" in newKeyCode) {
-                this.keymap.ChangeKey(this.waitingLayer, this.waitingIndex, newKeyCode, this.waitingIsEncoder);
-
-            }
-            else if ("r" in newKeyCode) {
-                // console.log("I must be a color", newKeyCode)
-                this.keymap.ChangeLed(this.waitingLayer, this.waitingIndex, newKeyCode)
-                if (this.keymap.keyLayout.features.split) {
-                    this.ledChangesMadeAndIsSplit = true
-                }
-            }
-            this.waitingIndex = undefined;
-            this.waitingLayer = undefined;
-            this.waitingIsLed = false;
-            this.waitingKey = false;
-            this.updateSubScribers()
-
-        }
-    }
-    public ForceKeyChange(layer: number, pos: number, newKey: KeyCode | Color, isEncoder: boolean) {
-        if (isKeyCode(newKey)) {
-            this.keymap.ChangeKey(layer, pos, newKey, isEncoder);
-        } else {
-            this.keymap.ChangeLed(layer, pos, newKey);
-            if (this.keymap.keyLayout.features.split) {
-                this.ledChangesMadeAndIsSplit = true
-            }
-        }
-        this.changesMade = true
-        this.updateSubScribers()
-        Toast.Debug(`forcing all key change:  ${JSON.stringify({ layer, pos, newKey, isEncoder })} `)
-
-    }
-    public ForceAllLedChange(newColor: Color) {
-        this.keymap.ChangeAllLeds(newColor)
-        if (this.keymap.keyLayout.features.split) {
-            this.ledChangesMadeAndIsSplit = true
-        }
-        this.changesMade = true
-        this.updateSubScribers()
-        Toast.Debug(`forcing all leds to new color:  ${JSON.stringify(newColor)} `)
-
-    }
-    public RemoveCodeBlock(index: number) {
-        this.keymap.RemoveCodeBlock(index)
-        this.NoticeAChangeWasMade()
-    }
-
-    public NoticeAChangeWasMade() {
-        this.changesMade = true
-        this.updateSubScribers()
-    }
-
-    public SaveMap() {
-        Toast.Debug(`wanting to save map`)
-        if (this.changesMade) {
-            Toast.Info(`Saving Changes Dont Unplug Your Keyboard`)
-            this.canUnplug = false
-            this.sendToBackend(ElectronEvents.SaveMap, this.keymap.toString())
-            this.changesMade = false
-            Toast.Debug(`saving map`)
-        }
-        if (this.ledChangesMadeAndIsSplit) {
-            Toast.Info(`Saving Changes Dont Unplug Your Keyboard`)
-            const modal = Modal.getInstance()
-            modal.OpenDefault("Split LED Flashing", false, ModalDefault.SplitFlashManager)
-            this.dontOverRide = true
-            Toast.Debug(`handling split led changes `)
-        }
-
-    }
-    public ChangeSplitFlashDisplayState = (newDisplayState: SplitFlashStage) => {
-        this.SplitFlashDisplayState = newDisplayState
-        switch (newDisplayState) {
-            case SplitFlashStage.Unplugged:
-                this.sendToBackend(ElectronEvents.FreshDriveScan, "")
-                Toast.Debug(`SplitFlashStage.Unplugged`)
-                break;
-            case SplitFlashStage.OffSide:
-                if (this.keymap.keyLayout.features.rightSide) {
-                    this.changesMade = true
-                    setTimeout(() => {
-                        this.SaveMap()
-                    }, 1000);
-
-                    this.ledChangesMadeAndIsSplit = false
-                    Toast.Debug(`SplitFlashStage.OffSide`)
-                }
-            default:
-                break;
-        }
-        this.updateSubScribers()
-    }
-
-    async pingServer() {
-        axios.get(`${this.programSettings.apiUrl}hp-check`).then(() => {
-            this.isOnLine = true
-            Toast.Debug(`server on line`)
-        }).catch(() => {
-            this.isOnLine = false
-            this.updateSubScribers()
-            Toast.Debug(`error from server hp-check`)
-
-        })
-    }
-
-    sendToBackend(key: ElectronEvents, data: any) {
-        //@ts-ignore
-        window.electron.ipcRenderer.send(key, data)
-
-    }
-    lessonToEvent(key: ElectronEvents, callBack: (args: any) => void) {
-        //@ts-ignore
-        window.electron.ipcRenderer.on(key, (arg: any) => {
-            try {
-                callBack(arg)
-            } catch (error) {
-                Toast.Error(`error in handling event:${key}`)
-
-                console.log("error in handling event from backend", `event:${key}`, error)
-            }
-
-        })
-    }
-
+				console.log(
+					"error in handling event from backend",
+					`event:${key}`,
+					error
+				);
+			}
+		});
+	}
 }

--- a/src/logic/diskManager.ts
+++ b/src/logic/diskManager.ts
@@ -1,505 +1,525 @@
-import { app } from 'electron';
-import { download } from "electron-dl"
+import { app } from "electron";
+import { download } from "electron-dl";
 //@ts-ignore
 import { AppManager } from "./AppManager";
-const nodeDiskInfo = require('node-disk-info')
+const nodeDiskInfo = require("node-disk-info");
 const bitmapManipulation = require("bitmap-manipulation");
 
-import * as fs from 'fs/promises';
-import path from 'path'
+import * as fs from "fs/promises";
+import path from "path";
 import { ElectronEvents, FileName, Layout, ToastLevel } from "../types/types";
 import { ProgramSettings } from "./programSettings";
 //@ts-ignore
-import DecompressZip from 'decompress-zip'
+import DecompressZip from "decompress-zip";
 
-const programSettings = ProgramSettings.getInstance()
+const programSettings = ProgramSettings.getInstance();
 type DiskInfo = {
-    filesystem: string
-    blocks: number
-    used: number
-    available: number
-    capacity: string
-    mounted: string
-}
+	filesystem: string;
+	blocks: number;
+	used: number;
+	available: number;
+	capacity: string;
+	mounted: string;
+};
 export class DiskManager {
+	keymap: string = "";
+	kbDrive: string = "";
+	hasKeymap: string = "";
+	hasLayout: string = "";
+	kmkPath: string = "";
+	didNotFindDrive: boolean = false;
+	keepLooking: boolean = true;
+	isScaning: boolean = false;
+	haveToldClientAboutScaning: boolean = false;
+	interval?: NodeJS.Timeout;
+	currentLayout?: Layout;
+	appManager: AppManager;
+	fromSplitManager: boolean = false;
+	constructor(appManager: AppManager) {
+		this.appManager = appManager;
+		console.log("setting up diskmanager");
+		this.loadFromCacheIfCan();
+		this.kmkPath = path.join(app.getPath("temp"), "kmk.zip");
+	}
 
-    keymap: string = "";
-    kbDrive: string = "";
-    hasKeymap: string = "";
-    hasLayout: string = "";
-    kmkPath: string = ""
-    didNotFindDrive: boolean = false;
-    keepLooking: boolean = true;
-    isScaning: boolean = false;
-    haveToldClientAboutScaning: boolean = false;
-    interval?: NodeJS.Timeout
-    currentLayout?: Layout
-    appManager: AppManager;
-    fromSplitManager: boolean = false
-    constructor(appManager: AppManager) {
-        this.appManager = appManager
-        console.log("setting up diskmanager")
-        this.loadFromCacheIfCan()
-        this.kmkPath = path.join(app.getPath("temp"), 'kmk.zip')
-    }
+	async loadFromCacheIfCan() {
+		const dataStr = await this.readCache();
+		console.log("trying to read cache:", dataStr);
+		if (dataStr !== "") {
+			const data = JSON.parse(dataStr);
+			this.hasLayout = data.hasLayout;
+			this.hasKeymap = data.hasKeymap;
+			this.kbDrive = data.kbDrive;
+			this.didNotFindDrive = false;
+		}
+	}
 
+	delay(time: number) {
+		// console.log("buying time")
+		return new Promise((res) => setTimeout(res, time));
+	}
 
-    async loadFromCacheIfCan() {
-        const dataStr = await this.readCache()
-        console.log("trying to read cache:", dataStr)
-        if (dataStr !== "") {
-            const data = JSON.parse(dataStr)
-            this.hasLayout = data.hasLayout
-            this.hasKeymap = data.hasKeymap
-            this.kbDrive = data.kbDrive
-            this.didNotFindDrive = false
-        }
-    }
+	public async freshDriveScan(fromSplitManager: boolean = false) {
+		this.fromSplitManager = fromSplitManager;
+		this.keymap = "";
+		this.kbDrive = "";
+		this.hasKeymap = "";
+		this.hasLayout = "";
+		this.didNotFindDrive = false;
+		this.keepLooking = true;
+		this.isScaning = false;
+		this.currentLayout = undefined;
+		this.cacheData("");
+		this.manageDriveScan();
+	}
+	public getDrivePath(): string {
+		return this.kbDrive;
+	}
+	holdCurrentBoard(layout: string) {
+		let change = false;
+		try {
+			const tempLayout: Layout = JSON.parse(layout);
+			if (
+				!this.currentLayout &&
+				tempLayout.features !== undefined &&
+				tempLayout.features.name !== undefined &&
+				tempLayout.features.creator !== undefined &&
+				tempLayout.features.rightSide !== undefined
+			) {
+				this.currentLayout = tempLayout;
+				console.log("saving what we have");
+			}
+			if (
+				this.currentLayout !== undefined &&
+				tempLayout.features !== undefined &&
+				tempLayout.features.name !== undefined &&
+				tempLayout.features.creator !== undefined &&
+				tempLayout.features.rightSide !== undefined
+			) {
+				if (
+					tempLayout.features.name !== this.currentLayout.features.name ||
+					tempLayout.features.creator !== this.currentLayout.features.creator ||
+					tempLayout.features.rightSide !==
+						this.currentLayout.features.rightSide
+				) {
+					console.log("we got changes");
+					change = true;
+				}
+			}
+		} catch (error) {
+			console.log("error reading json", error);
+		}
+		return change;
+	}
+	async pingDrive() {
+		try {
+			const files = await fs.readdir(this.kbDrive);
+			if (files.includes("main.py") && files.includes("layout.json")) {
+				if (this.hasLayout !== "") {
+					const layoutJson = await fs.readFile(this.hasLayout, "utf8");
+					const hasChanged = this.holdCurrentBoard(layoutJson);
+					if (hasChanged) {
+						this.appManager.SendMiscEvent(ElectronEvents.BoardChange, "");
+						if (this.interval) {
+							clearInterval(this.interval);
+							this.interval = undefined;
+						}
+						if (!this.fromSplitManager) {
+							this.freshDriveScan();
+						}
+					}
+				}
+			}
+		} catch (error) {
+			if (!this.fromSplitManager) {
+				this.appManager.SendMiscEvent(ElectronEvents.LostConnectionToBoard, "");
+				this.freshDriveScan();
+			}
+		}
+	}
+	async managePingDrive() {
+		if (this.kbDrive !== "") {
+			if (this.interval === undefined) {
+				const intervalTime = 5000;
+				const interval = setInterval(() => {
+					this.pingDrive();
+				}, intervalTime);
+				this.interval = interval;
+			}
+		} else {
+			if (!this.isScaning) {
+				await this.scanDrives(true);
+			} else {
+				// await  this.delay(10000)
+				//         this.managePingDrive()
+			}
+		}
+	}
 
-    delay(time: number) {
-        // console.log("buying time")
-        return new Promise(res => setTimeout(res, time))
-    };
+	public async DownloadAndInstallLib(BoardName: string, drivePath: string) {
+		try {
+			const libDir = path.join(drivePath, "lib");
+			await fs.rm(libDir, { recursive: true });
+			console.log(`${libDir} is deleted!`);
+		} catch (error) {
+			console.log("error removing old libs", error);
+		}
+		download(
+			this.appManager.win,
+			`${programSettings.apiUrl}lib/${BoardName}.zip`,
+			{
+				directory: app.getPath("temp"),
+				filename: `${BoardName}.zip`,
+				onCompleted: (file: any) => {
+					try {
+						const srcPath = path.join(app.getPath("temp"), `${BoardName}.zip`);
+						const zip = new DecompressZip(srcPath);
+						zip.extract({
+							path: drivePath,
+						});
+						zip.on("extract", () => {
+							this.appManager.ClientToast(ToastLevel.success, "Installed libs");
+						});
+						zip.on("error", () => {
+							this.appManager.ClientToast(
+								ToastLevel.error,
+								"Error extracting libs"
+							);
+						});
+					} catch (error) {
+						console.log("error extracting libs", error);
+						this.appManager.ClientToast(
+							ToastLevel.error,
+							"Error extracting libs"
+						);
+					}
+				},
+			}
+		).catch((error: Error) => {
+			console.log("error downloading libs", error);
+			this.appManager.ClientToast(ToastLevel.error, "Error downloading libs");
+		});
+	}
 
-    public async freshDriveScan(fromSplitManager: boolean = false) {
-        this.fromSplitManager = fromSplitManager
-        this.keymap = "";
-        this.kbDrive = "";
-        this.hasKeymap = "";
-        this.hasLayout = "";
-        this.didNotFindDrive = false;
-        this.keepLooking = true;
-        this.isScaning = false;
-        this.currentLayout = undefined
-        this.cacheData("")
-        this.manageDriveScan()
+	public async DownloadKmk() {
+		download(this.appManager.win, `${programSettings.apiUrl}kmk.zip`, {
+			directory: app.getPath("temp"),
+			filename: "kmk.zip",
+			onCompleted: (file: any) => {
+				this.appManager.ClientToast(ToastLevel.success, "Downloaded KmK");
+			},
+		}).catch((error: Error) => {
+			console.log("Error", error);
+		});
+	}
 
-    }
-    holdCurrentBoard(layout: string) {
-        let change = false
-        try {
-            const tempLayout: Layout = JSON.parse(layout)
-            if (!this.currentLayout && tempLayout.features !== undefined && tempLayout.features.name !== undefined && tempLayout.features.creator !== undefined && tempLayout.features.rightSide !== undefined) {
-                this.currentLayout = tempLayout
-                console.log("saving what we have")
-            }
-            if (this.currentLayout !== undefined && tempLayout.features !== undefined && tempLayout.features.name !== undefined && tempLayout.features.creator !== undefined && tempLayout.features.rightSide !== undefined) {
-                if (tempLayout.features.name !== this.currentLayout.features.name || tempLayout.features.creator !== this.currentLayout.features.creator || tempLayout.features.rightSide !== this.currentLayout.features.rightSide) {
-                    console.log("we got changes")
-                    change = true
-                }
-            }
+	public async InstallKmk(drivePath: string) {
+		try {
+			const zip = new DecompressZip(this.kmkPath);
+			zip.extract({
+				path: drivePath,
+			});
+			zip.on("extract", () => {
+				this.appManager.ClientToast(ToastLevel.success, "Installed KmK");
+			});
+			zip.on("error", (error: any) => {
+				console.log("error extracting kmk", error);
+				this.appManager.ClientToast(ToastLevel.error, "Error extracting KmK");
+			});
+		} catch (error) {
+			console.log("error extracting kmk", error);
+			this.appManager.ClientToast(ToastLevel.error, "Error extracting KmK");
+		}
+	}
+	public async manageDriveScan() {
+		try {
+			// console.log("ManageDrive")
+			if (
+				!this.didNotFindDrive &&
+				this.hasKeymap !== "" &&
+				this.hasLayout !== ""
+			) {
+				const layoutjson = await fs.readFile(this.hasLayout, "utf8");
+				this.appManager.UpdateLayout(layoutjson);
+				const mainPy = await fs.readFile(this.hasKeymap, "utf8");
+				this.appManager.UpdateKeyMap(mainPy);
+				return;
+			}
+			if (!this.isScaning) {
+				this.isScaning = true;
+				await this.scanDrives();
+				if (this.didNotFindDrive && this.keepLooking) {
+					// console.log("scaning again")
+					if (!this.haveToldClientAboutScaning) {
+						this.appManager.SendMiscEvent(
+							ElectronEvents.ScanAgain,
+							"scaning again"
+						);
+						this.haveToldClientAboutScaning = true;
+					}
+					await this.delay(5000);
+					this.manageDriveScan();
+				}
+			}
+		} catch (error) {
+			console.log("error in scanning again", error, this);
+		}
+		this.managePingDrive();
+	}
+	async readProPlan() {
+		try {
+			const tmpPath = path.join(app.getPath("temp"), "ppp.temp");
+			const data = await fs.readFile(tmpPath, "utf8");
+			this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true);
+		} catch (error) {
+			this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true);
+			console.log("error in reading pro plan", error);
+			return "";
+		}
+	}
 
-        } catch (error) {
-            console.log("error reading json", error)
-        }
-        return change
-    }
-    async pingDrive() {
-        try {
-            const files = await fs.readdir(this.kbDrive);
-            if (files.includes("main.py") && files.includes("layout.json")) {
-                if (this.hasLayout !== "") {
-                    const layoutJson = await fs.readFile(this.hasLayout, 'utf8');
-                    const hasChanged = this.holdCurrentBoard(layoutJson)
-                    if (hasChanged) {
-                        this.appManager.SendMiscEvent(ElectronEvents.BoardChange, "")
-                        if (this.interval) {
-                            clearInterval(this.interval);
-                            this.interval = undefined
-                        }
-                        if (!this.fromSplitManager) {
-                            this.freshDriveScan()
-                        }
-                    }
+	async setProPlan(id: string) {
+		try {
+			console.log("settings pro plan", id);
+			const data = id;
+			const tmpPath = path.join(app.getPath("temp"), "ppp.temp");
+			const newFile = await fs.writeFile(tmpPath, data, "utf8");
+			this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true);
 
-                }
-            }
-        } catch (error) {
-            if (!this.fromSplitManager) {
-                this.appManager.SendMiscEvent(ElectronEvents.LostConnectionToBoard, "")
-                this.freshDriveScan()
-            }
+			// console.log("newFile from cache", newFile)
+		} catch (error) {
+			console.log("error in writing pro plan", error);
+		}
+	}
 
-        }
-    }
-    async managePingDrive() {
-        if (this.kbDrive !== "") {
-            if (this.interval === undefined) {
-                const intervalTime = 5000
-                const interval = setInterval(() => {
-                    this.pingDrive()
-                }, intervalTime)
-                this.interval = interval
-            }
-        } else {
-            if (!this.isScaning) {
-                await this.scanDrives(true)
-            } else {
-                // await  this.delay(10000)
-                //         this.managePingDrive()
+	async readCache(): Promise<string> {
+		try {
+			const tmpPath = path.join(app.getPath("temp"), "peg.temp");
+			const data = await fs.readFile(tmpPath, "utf8");
+			return data;
+		} catch (error) {
+			console.log("error in reading cache data", error);
+			return "";
+		}
+	}
 
-            }
+	async cacheData(data: string) {
+		try {
+			const tmpPath = path.join(app.getPath("temp"), "peg.temp");
+			const newFile = await fs.writeFile(tmpPath, data, "utf8");
+			// console.log("newFile from cache", newFile)
+		} catch (error) {
+			console.log("error in writing cache data", error);
+		}
+	}
 
-        }
-    }
+	async readSettings(event: ElectronEvents, fileName: FileName) {
+		try {
+			const tmpPath = path.join(app.getPath("appData"), fileName);
+			const data = await fs.readFile(tmpPath, "utf8");
+			this.appManager.SendMiscEvent(event, data);
+			console.log("reading Settings", tmpPath);
+		} catch (error) {
+			console.log("error in reading cache data", error);
+			return "";
+		}
+	}
 
+	async saveSettings(data: string, fileName: FileName) {
+		try {
+			const tmpPath = path.join(app.getPath("appData"), fileName);
+			const newFile = await fs.writeFile(tmpPath, data, "utf8");
+			console.log("saving Settings");
+		} catch (error) {
+			console.log("error in writing settings data", error);
+		}
+	}
 
-    public async DownloadAndInstallLib(BoardName: string, drivePath: string) {
-        try {
-            const libDir = path.join(drivePath, "lib")
-            await fs.rm(libDir, { recursive: true });
-            console.log(`${libDir} is deleted!`);
-        } catch (error) {
-            console.log("error removing old libs", error)
-        }
-        download(this.appManager.win, `${programSettings.apiUrl}lib/${BoardName}.zip`, {
-            directory: app.getPath("temp"),
-            filename: `${BoardName}.zip`,
-            onCompleted: (file: any) => {
-                try {
-                    const srcPath = path.join(app.getPath("temp"), `${BoardName}.zip`)
-                    const zip = new DecompressZip(srcPath);
-                    zip.extract({
-                        path: drivePath,
-                    });
-                    zip.on("extract", () => {
-                        this.appManager.ClientToast(ToastLevel.success, "Installed libs")
-                    })
-                    zip.on("error", () => {
-                        this.appManager.ClientToast(ToastLevel.error, "Error extracting libs")
-                    })
+	public async scanDrives(dontUpdate: boolean = false) {
+		try {
+			// console.log("scanDrives")
+			const disks = await nodeDiskInfo.getDiskInfo();
 
-                } catch (error) {
-                    console.log("error extracting libs", error)
-                    this.appManager.ClientToast(ToastLevel.error, "Error extracting libs")
+			for (const disk of disks) {
+				// console.log("disk of disks")
+				if (process.platform !== "win32") {
+					if (!disk.mounted.startsWith("/") || disk.used === 0) {
+						console.log("not messing with ");
+						continue;
+					}
+				}
 
-                }
-            }
-        }).catch((error: Error) => {
-            console.log("error downloading libs", error)
-            this.appManager.ClientToast(ToastLevel.error, "Error downloading libs")
+				try {
+					// console.log("readdir")
+					const files = await fs.readdir(disk.mounted);
+					if (files.includes("main.py") && files.includes("layout.json")) {
+						this.kbDrive = `${disk.mounted}/`;
+						this.hasKeymap = `${this.kbDrive}main.py`;
+						this.hasLayout = `${this.kbDrive}layout.json`;
+						break;
+					}
+				} catch (error) {
+					console.log("this is not the drive you are looking for", error);
+					continue;
+				}
+			}
+			if (this.kbDrive !== "") {
+				this.didNotFindDrive = false;
+				this.haveToldClientAboutScaning = false;
+				this.fromSplitManager = false;
+				let tempData: any = { kbDrive: this.kbDrive };
 
+				if (this.hasKeymap !== "") {
+					const mainPy = await fs.readFile(this.hasKeymap, "utf8");
+					if (!dontUpdate) {
+						this.appManager.UpdateKeyMap(mainPy);
+					}
 
+					tempData["hasKeymap"] = this.hasKeymap;
+				}
+				if (this.hasLayout !== "") {
+					const layoutjson = await fs.readFile(this.hasLayout, "utf8");
+					if (!dontUpdate) {
+						this.appManager.UpdateLayout(layoutjson);
+					}
+					tempData["hasLayout"] = this.hasLayout;
+				}
+				this.cacheData(JSON.stringify(tempData));
+			} else {
+				this.didNotFindDrive = true;
+				this.isScaning = false;
+			}
+		} catch (err) {
+			console.error("err in  scanDrives: ", err);
+		}
+	}
 
-        })
+	public async saveFile(newMap: string, retry: boolean = false) {
+		try {
+			if (this.kbDrive !== "") {
+				if (this.hasKeymap !== "") {
+					const newFile = await fs.writeFile(this.hasKeymap, newMap, "utf8");
+					this.appManager.SendMiscEvent(ElectronEvents.MapSaved, "");
+					console.log("newFile from save", newFile);
+				}
+			} else {
+				if (!retry) {
+					await this.loadFromCacheIfCan();
+					this.saveFile(newMap, true);
+				} else {
+					await this.scanDrives(true);
+					this.saveFile(newMap, true);
+				}
+				//todo alaert user map did not update
+				console.log("dont have the needed stuff");
+			}
+		} catch (error) {
+			console.log("error in writing map", error);
+			this.appManager.ClientToast(ToastLevel.error, `Error in saving map.`);
 
+			//todo alaert user map did not update
+		}
+	}
 
-    }
+	public async writeData(data: { fileData: string; path: string[] }) {
+		try {
+			const writepath = path.join(...data.path);
+			const newFile = await fs.writeFile(writepath, data.fileData, "utf8");
+			console.log("force write data");
+			if (data.path[1] === FileName.main) {
+				const codePyPath = path.join(data.path[0], "code.py");
+				const files = await fs.readdir(data.path[0]);
+				if (files.includes("code.py")) {
+					console.log("removing code.py");
+					fs.unlink(codePyPath);
+				}
+			} else {
+				this.appManager.ClientToast(
+					ToastLevel.success,
+					`${data.path[1]} Saved`
+				);
+			}
+		} catch (error) {
+			this.appManager.ClientToast(
+				ToastLevel.error,
+				`Error when saving ${path.join("/")}`
+			);
+			console.log("error in writing map", error);
+			//todo alaert user map did not update
+		}
+	}
 
-    public async DownloadKmk() {
-        download(this.appManager.win, `${programSettings.apiUrl}kmk.zip`, {
-            directory: app.getPath("temp"),
-            filename: "kmk.zip",
-            onCompleted: (file: any) => {
-                this.appManager.ClientToast(ToastLevel.success, "Downloaded KmK")
-            }
+	public async wrightOledBmp(
+		fileData: number[][],
+		fileNumber: number | string,
+		retry: boolean = false
+	) {
+		try {
+			if (this.kbDrive !== "") {
+				let bitmap = new bitmapManipulation.BMPBitmap(128, 32, 1);
+				fileData.forEach((row, i) => {
+					row.forEach((pxl, ii) => {
+						if (pxl === 1) {
+							bitmap.setPixel(ii, i, 0xff);
+						}
+					});
+				});
+				bitmap.save(`${this.kbDrive}/${fileNumber}.bmp`);
+			} else {
+				if (!retry) {
+					await this.loadFromCacheIfCan();
+					this.wrightOledBmp(fileData, fileNumber, true);
+				} else {
+					await this.scanDrives(true);
+					this.wrightOledBmp(fileData, fileNumber, true);
+				}
+				//todo alaert user map did not update
+				console.log("dont have the needed stuff");
+				// console.log("missing kb drive", this)
+			}
+		} catch (error) {
+			console.log("error in writing map", error);
 
-        }).catch((error: Error) => { console.log("Error", error) })
-    }
+			//todo alaert user map did not update
+		}
+	}
 
-
-
-    public async InstallKmk(drivePath: string) {
-        try {
-            const zip = new DecompressZip(this.kmkPath);
-            zip.extract({
-                path: drivePath,
-            });
-            zip.on("extract", () => {
-                this.appManager.ClientToast(ToastLevel.success, "Installed KmK")
-            })
-            zip.on("error", (error: any) => {
-                console.log("error extracting kmk", error)
-                this.appManager.ClientToast(ToastLevel.error, "Error extracting KmK")
-            })
-        } catch (error) {
-            console.log("error extracting kmk", error)
-            this.appManager.ClientToast(ToastLevel.error, "Error extracting KmK")
-        }
-
-    }
-    public async manageDriveScan() {
-        try {
-            // console.log("ManageDrive")
-            if (!this.didNotFindDrive && this.hasKeymap !== "" && this.hasLayout !== "") {
-                const layoutjson = await fs.readFile(this.hasLayout, 'utf8');
-                this.appManager.UpdateLayout(layoutjson)
-                const mainPy = await fs.readFile(this.hasKeymap, 'utf8');
-                this.appManager.UpdateKeyMap(mainPy)
-                return
-            }
-            if (!this.isScaning) {
-                this.isScaning = true
-                await this.scanDrives()
-                if (this.didNotFindDrive && this.keepLooking) {
-                    // console.log("scaning again")
-                    if (!this.haveToldClientAboutScaning) {
-                        this.appManager.SendMiscEvent(ElectronEvents.ScanAgain, "scaning again")
-                        this.haveToldClientAboutScaning = true
-                    }
-                    await this.delay(5000)
-                    this.manageDriveScan()
-                }
-            }
-
-        } catch (error) {
-            console.log("error in scanning again", error, this)
-        }
-        this.managePingDrive()
-
-    }
-    async readProPlan() {
-        try {
-            const tmpPath = path.join(app.getPath("temp"), 'ppp.temp')
-            const data = await fs.readFile(tmpPath, 'utf8');
-            this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true)
-
-        } catch (error) {
-            this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true)
-            console.log("error in reading pro plan", error)
-            return ""
-        }
-    }
-
-    async setProPlan(id: string) {
-        try {
-
-            console.log("settings pro plan", id)
-            const data = id
-            const tmpPath = path.join(app.getPath("temp"), 'ppp.temp')
-            const newFile = await fs.writeFile(tmpPath, data, 'utf8');
-            this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true)
-
-            // console.log("newFile from cache", newFile)
-        } catch (error) {
-            console.log("error in writing pro plan", error)
-        }
-    }
-
-    async readCache(): Promise<string> {
-        try {
-            const tmpPath = path.join(app.getPath("temp"), 'peg.temp')
-            const data = await fs.readFile(tmpPath, 'utf8');
-            return data
-
-        } catch (error) {
-            console.log("error in reading cache data", error)
-            return ""
-        }
-    }
-
-    async cacheData(data: string) {
-        try {
-            const tmpPath = path.join(app.getPath("temp"), 'peg.temp')
-            const newFile = await fs.writeFile(tmpPath, data, 'utf8');
-            // console.log("newFile from cache", newFile)
-        } catch (error) {
-            console.log("error in writing cache data", error)
-        }
-    }
-
-    async readSettings(event: ElectronEvents, fileName: FileName) {
-        try {
-            const tmpPath = path.join(app.getPath("appData"), fileName)
-            const data = await fs.readFile(tmpPath, 'utf8');
-            this.appManager.SendMiscEvent(event, data)
-            console.log("reading Settings", tmpPath)
-
-        } catch (error) {
-            console.log("error in reading cache data", error)
-            return ""
-        }
-    }
-
-    async saveSettings(data: string, fileName: FileName) {
-        try {
-            const tmpPath = path.join(app.getPath("appData"), fileName)
-            const newFile = await fs.writeFile(tmpPath, data, 'utf8');
-            console.log("saving Settings")
-        } catch (error) {
-            console.log("error in writing settings data", error)
-        }
-
-    }
-
-    public async scanDrives(dontUpdate: boolean = false) {
-        try {
-            // console.log("scanDrives")
-            const disks = await nodeDiskInfo.getDiskInfo()
-
-            for (const disk of disks) {
-                // console.log("disk of disks")
-                if (process.platform !== "win32") {
-                    if (!disk.mounted.startsWith("/") || disk.used === 0) {
-                        console.log("not messing with ")
-                        continue
-                    }
-                }
-
-                try {
-                    // console.log("readdir")
-                    const files = await fs.readdir(disk.mounted);
-                    if (files.includes("main.py") && files.includes("layout.json")) {
-                        this.kbDrive = `${disk.mounted}/`;
-                        this.hasKeymap = `${this.kbDrive}main.py`
-                        this.hasLayout = `${this.kbDrive}layout.json`
-                        break
-                    }
-                } catch (error) {
-                    console.log("this is not the drive you are looking for", error)
-                    continue
-                }
-
-            }
-            if (this.kbDrive !== "") {
-                this.didNotFindDrive = false;
-                this.haveToldClientAboutScaning = false
-                this.fromSplitManager = false
-                let tempData: any = { kbDrive: this.kbDrive }
-
-                if (this.hasKeymap !== "") {
-                    const mainPy = await fs.readFile(this.hasKeymap, 'utf8');
-                    if (!dontUpdate) {
-                        this.appManager.UpdateKeyMap(mainPy)
-                    }
-
-                    tempData["hasKeymap"] = this.hasKeymap
-                }
-                if (this.hasLayout !== "") {
-                    const layoutjson = await fs.readFile(this.hasLayout, 'utf8');
-                    if (!dontUpdate) {
-                        this.appManager.UpdateLayout(layoutjson)
-                    }
-                    tempData["hasLayout"] = this.hasLayout
-                }
-                this.cacheData(JSON.stringify(tempData))
-            }
-            else {
-                this.didNotFindDrive = true;
-                this.isScaning = false
-
-            }
-
-        } catch (err) {
-            console.error("err in  scanDrives: ", err);
-        }
-
-    }
-
-    public async saveFile(newMap: string, retry: boolean = false) {
-        try {
-            if (this.kbDrive !== "") {
-                if (this.hasKeymap !== "") {
-                    const newFile = await fs.writeFile(this.hasKeymap, newMap, 'utf8');
-                    this.appManager.SendMiscEvent(ElectronEvents.MapSaved, "")
-                    console.log("newFile from save", newFile)
-                }
-            }
-            else {
-                if (!retry) {
-                    await this.loadFromCacheIfCan()
-                    this.saveFile(newMap, true)
-                } else {
-                    await this.scanDrives(true)
-                    this.saveFile(newMap, true)
-
-                }
-                //todo alaert user map did not update
-                console.log("dont have the needed stuff")
-
-            }
-        } catch (error) {
-            console.log("error in writing map", error)
-            this.appManager.ClientToast(ToastLevel.error, `Error in saving map.`)
-
-            //todo alaert user map did not update
-        }
-
-    }
-
-    public async writeData(data: { fileData: string, path: string[] }) {
-        try {
-            const writepath = path.join(...data.path)
-            const newFile = await fs.writeFile(writepath, data.fileData, 'utf8');
-            console.log("force write data")
-            if (data.path[1] === FileName.main) {
-                const codePyPath = path.join(data.path[0], "code.py")
-                const files = await fs.readdir(data.path[0]);
-                if (files.includes("code.py")) {
-                    console.log("removing code.py")
-                    fs.unlink(codePyPath)
-                }
-            } else {
-                this.appManager.ClientToast(ToastLevel.success, `${data.path[1]} Saved`)
-            }
-        } catch (error) {
-            this.appManager.ClientToast(ToastLevel.error, `Error when saving ${path.join("/")}`)
-            console.log("error in writing map", error)
-            //todo alaert user map did not update
-        }
-
-    }
-
-    public async wrightOledBmp(fileData: number[][], fileNumber: number | string, retry: boolean = false) {
-        try {
-            if (this.kbDrive !== "") {
-
-                let bitmap = new bitmapManipulation.BMPBitmap(128, 32, 1);
-                fileData.forEach((row, i) => {
-                    row.forEach((pxl, ii) => {
-                        if (pxl === 1) {
-                            bitmap.setPixel(ii, i, 0xff)
-                        }
-                    })
-                })
-                bitmap.save(`${this.kbDrive}/${fileNumber}.bmp`);
-            } else {
-                if (!retry) {
-                    await this.loadFromCacheIfCan()
-                    this.wrightOledBmp(fileData, fileNumber, true)
-                } else {
-                    await this.scanDrives(true)
-                    this.wrightOledBmp(fileData, fileNumber, true)
-                }
-                //todo alaert user map did not update
-                console.log("dont have the needed stuff")
-                // console.log("missing kb drive", this)
-            }
-        } catch (error) {
-            console.log("error in writing map", error)
-
-            //todo alaert user map did not update
-        }
-    }
-
-    public async readOledBmp(fileNumber: number | string, retry: boolean = false) {
-        console.log("drive letter", this.kbDrive)
-        if (this.kbDrive !== "") {
-            console.log(" I got to look for a bmp by the number of ", this, fileNumber, `${this.kbDrive}${fileNumber}.bmp`)
-            let data = []
-            let oldFile = bitmapManipulation.BMPBitmap.fromFile(`${this.kbDrive}${fileNumber}.bmp`)
-            for (let row = 0; row < 32; row++) {
-                let tempRow = []
-                for (let col = 0; col < 128; col++) {
-                    const value = oldFile.getPixel(col, row)
-                    tempRow.push(value === 255 ? 1 : 0)
-                }
-                data.push(tempRow)
-            }
-            this.appManager.UpdateOled(data, fileNumber)
-        } else {
-            if (!retry) {
-                await this.loadFromCacheIfCan()
-                this.readOledBmp(fileNumber, true)
-            } else {
-                await this.scanDrives(true)
-                this.readOledBmp(fileNumber, true)
-            }
-            //todo alaert user map did not update
-            console.log("dont have the needed stuff")
-            console.log("missing kb drive", this)
-        }
-
-    }
+	public async readOledBmp(
+		fileNumber: number | string,
+		retry: boolean = false
+	) {
+		console.log("drive letter", this.kbDrive);
+		if (this.kbDrive !== "") {
+			console.log(
+				" I got to look for a bmp by the number of ",
+				this,
+				fileNumber,
+				`${this.kbDrive}${fileNumber}.bmp`
+			);
+			let data = [];
+			let oldFile = bitmapManipulation.BMPBitmap.fromFile(
+				`${this.kbDrive}${fileNumber}.bmp`
+			);
+			for (let row = 0; row < 32; row++) {
+				let tempRow = [];
+				for (let col = 0; col < 128; col++) {
+					const value = oldFile.getPixel(col, row);
+					tempRow.push(value === 255 ? 1 : 0);
+				}
+				data.push(tempRow);
+			}
+			this.appManager.UpdateOled(data, fileNumber);
+		} else {
+			if (!retry) {
+				await this.loadFromCacheIfCan();
+				this.readOledBmp(fileNumber, true);
+			} else {
+				await this.scanDrives(true);
+				this.readOledBmp(fileNumber, true);
+			}
+			//todo alaert user map did not update
+			console.log("dont have the needed stuff");
+			console.log("missing kb drive", this);
+		}
+	}
 }

--- a/src/logic/diskManager.ts
+++ b/src/logic/diskManager.ts
@@ -1,525 +1,508 @@
-import { app } from "electron";
-import { download } from "electron-dl";
+import { app } from 'electron';
+import { download } from "electron-dl"
 //@ts-ignore
 import { AppManager } from "./AppManager";
-const nodeDiskInfo = require("node-disk-info");
+const nodeDiskInfo = require('node-disk-info')
 const bitmapManipulation = require("bitmap-manipulation");
 
-import * as fs from "fs/promises";
-import path from "path";
+import * as fs from 'fs/promises';
+import path from 'path'
 import { ElectronEvents, FileName, Layout, ToastLevel } from "../types/types";
 import { ProgramSettings } from "./programSettings";
 //@ts-ignore
-import DecompressZip from "decompress-zip";
+import DecompressZip from 'decompress-zip'
 
-const programSettings = ProgramSettings.getInstance();
+const programSettings = ProgramSettings.getInstance()
 type DiskInfo = {
-	filesystem: string;
-	blocks: number;
-	used: number;
-	available: number;
-	capacity: string;
-	mounted: string;
-};
+    filesystem: string
+    blocks: number
+    used: number
+    available: number
+    capacity: string
+    mounted: string
+}
 export class DiskManager {
-	keymap: string = "";
-	kbDrive: string = "";
-	hasKeymap: string = "";
-	hasLayout: string = "";
-	kmkPath: string = "";
-	didNotFindDrive: boolean = false;
-	keepLooking: boolean = true;
-	isScaning: boolean = false;
-	haveToldClientAboutScaning: boolean = false;
-	interval?: NodeJS.Timeout;
-	currentLayout?: Layout;
-	appManager: AppManager;
-	fromSplitManager: boolean = false;
-	constructor(appManager: AppManager) {
-		this.appManager = appManager;
-		console.log("setting up diskmanager");
-		this.loadFromCacheIfCan();
-		this.kmkPath = path.join(app.getPath("temp"), "kmk.zip");
-	}
 
-	async loadFromCacheIfCan() {
-		const dataStr = await this.readCache();
-		console.log("trying to read cache:", dataStr);
-		if (dataStr !== "") {
-			const data = JSON.parse(dataStr);
-			this.hasLayout = data.hasLayout;
-			this.hasKeymap = data.hasKeymap;
-			this.kbDrive = data.kbDrive;
-			this.didNotFindDrive = false;
-		}
-	}
+    keymap: string = "";
+    kbDrive: string = "";
+    hasKeymap: string = "";
+    hasLayout: string = "";
+    kmkPath: string = ""
+    didNotFindDrive: boolean = false;
+    keepLooking: boolean = true;
+    isScaning: boolean = false;
+    haveToldClientAboutScaning: boolean = false;
+    interval?: NodeJS.Timeout
+    currentLayout?: Layout
+    appManager: AppManager;
+    fromSplitManager: boolean = false
+    constructor(appManager: AppManager) {
+        this.appManager = appManager
+        console.log("setting up diskmanager")
+        this.loadFromCacheIfCan()
+        this.kmkPath = path.join(app.getPath("temp"), 'kmk.zip')
+    }
 
-	delay(time: number) {
-		// console.log("buying time")
-		return new Promise((res) => setTimeout(res, time));
-	}
 
-	public async freshDriveScan(fromSplitManager: boolean = false) {
-		this.fromSplitManager = fromSplitManager;
-		this.keymap = "";
-		this.kbDrive = "";
-		this.hasKeymap = "";
-		this.hasLayout = "";
-		this.didNotFindDrive = false;
-		this.keepLooking = true;
-		this.isScaning = false;
-		this.currentLayout = undefined;
-		this.cacheData("");
-		this.manageDriveScan();
-	}
-	public getDrivePath(): string {
+    async loadFromCacheIfCan() {
+        const dataStr = await this.readCache()
+        console.log("trying to read cache:", dataStr)
+        if (dataStr !== "") {
+            const data = JSON.parse(dataStr)
+            this.hasLayout = data.hasLayout
+            this.hasKeymap = data.hasKeymap
+            this.kbDrive = data.kbDrive
+            this.didNotFindDrive = false
+        }
+    }
+
+    delay(time: number) {
+        // console.log("buying time")
+        return new Promise(res => setTimeout(res, time))
+    };
+
+    public async freshDriveScan(fromSplitManager: boolean = false) {
+        this.fromSplitManager = fromSplitManager
+        this.keymap = "";
+        this.kbDrive = "";
+        this.hasKeymap = "";
+        this.hasLayout = "";
+        this.didNotFindDrive = false;
+        this.keepLooking = true;
+        this.isScaning = false;
+        this.currentLayout = undefined
+        this.cacheData("")
+        this.manageDriveScan()
+
+    }
+    holdCurrentBoard(layout: string) {
+        let change = false
+        try {
+            const tempLayout: Layout = JSON.parse(layout)
+            if (!this.currentLayout && tempLayout.features !== undefined && tempLayout.features.name !== undefined && tempLayout.features.creator !== undefined && tempLayout.features.rightSide !== undefined) {
+                this.currentLayout = tempLayout
+                console.log("saving what we have")
+            }
+            if (this.currentLayout !== undefined && tempLayout.features !== undefined && tempLayout.features.name !== undefined && tempLayout.features.creator !== undefined && tempLayout.features.rightSide !== undefined) {
+                if (tempLayout.features.name !== this.currentLayout.features.name || tempLayout.features.creator !== this.currentLayout.features.creator || tempLayout.features.rightSide !== this.currentLayout.features.rightSide) {
+                    console.log("we got changes")
+                    change = true
+                }
+            }
+
+        } catch (error) {
+            console.log("error reading json", error)
+        }
+        return change
+    }
+    public getDrivePath(): string {
 		return this.kbDrive;
 	}
-	holdCurrentBoard(layout: string) {
-		let change = false;
-		try {
-			const tempLayout: Layout = JSON.parse(layout);
-			if (
-				!this.currentLayout &&
-				tempLayout.features !== undefined &&
-				tempLayout.features.name !== undefined &&
-				tempLayout.features.creator !== undefined &&
-				tempLayout.features.rightSide !== undefined
-			) {
-				this.currentLayout = tempLayout;
-				console.log("saving what we have");
-			}
-			if (
-				this.currentLayout !== undefined &&
-				tempLayout.features !== undefined &&
-				tempLayout.features.name !== undefined &&
-				tempLayout.features.creator !== undefined &&
-				tempLayout.features.rightSide !== undefined
-			) {
-				if (
-					tempLayout.features.name !== this.currentLayout.features.name ||
-					tempLayout.features.creator !== this.currentLayout.features.creator ||
-					tempLayout.features.rightSide !==
-						this.currentLayout.features.rightSide
-				) {
-					console.log("we got changes");
-					change = true;
-				}
-			}
-		} catch (error) {
-			console.log("error reading json", error);
-		}
-		return change;
-	}
-	async pingDrive() {
-		try {
-			const files = await fs.readdir(this.kbDrive);
-			if (files.includes("main.py") && files.includes("layout.json")) {
-				if (this.hasLayout !== "") {
-					const layoutJson = await fs.readFile(this.hasLayout, "utf8");
-					const hasChanged = this.holdCurrentBoard(layoutJson);
-					if (hasChanged) {
-						this.appManager.SendMiscEvent(ElectronEvents.BoardChange, "");
-						if (this.interval) {
-							clearInterval(this.interval);
-							this.interval = undefined;
-						}
-						if (!this.fromSplitManager) {
-							this.freshDriveScan();
-						}
-					}
-				}
-			}
-		} catch (error) {
-			if (!this.fromSplitManager) {
-				this.appManager.SendMiscEvent(ElectronEvents.LostConnectionToBoard, "");
-				this.freshDriveScan();
-			}
-		}
-	}
-	async managePingDrive() {
-		if (this.kbDrive !== "") {
-			if (this.interval === undefined) {
-				const intervalTime = 5000;
-				const interval = setInterval(() => {
-					this.pingDrive();
-				}, intervalTime);
-				this.interval = interval;
-			}
-		} else {
-			if (!this.isScaning) {
-				await this.scanDrives(true);
-			} else {
-				// await  this.delay(10000)
-				//         this.managePingDrive()
-			}
-		}
-	}
+    async pingDrive() {
+        try {
+            const files = await fs.readdir(this.kbDrive);
+            if (files.includes("main.py") && files.includes("layout.json")) {
+                if (this.hasLayout !== "") {
+                    const layoutJson = await fs.readFile(this.hasLayout, 'utf8');
+                    const hasChanged = this.holdCurrentBoard(layoutJson)
+                    if (hasChanged) {
+                        this.appManager.SendMiscEvent(ElectronEvents.BoardChange, "")
+                        if (this.interval) {
+                            clearInterval(this.interval);
+                            this.interval = undefined
+                        }
+                        if (!this.fromSplitManager) {
+                            this.freshDriveScan()
+                        }
+                    }
 
-	public async DownloadAndInstallLib(BoardName: string, drivePath: string) {
-		try {
-			const libDir = path.join(drivePath, "lib");
-			await fs.rm(libDir, { recursive: true });
-			console.log(`${libDir} is deleted!`);
-		} catch (error) {
-			console.log("error removing old libs", error);
-		}
-		download(
-			this.appManager.win,
-			`${programSettings.apiUrl}lib/${BoardName}.zip`,
-			{
-				directory: app.getPath("temp"),
-				filename: `${BoardName}.zip`,
-				onCompleted: (file: any) => {
-					try {
-						const srcPath = path.join(app.getPath("temp"), `${BoardName}.zip`);
-						const zip = new DecompressZip(srcPath);
-						zip.extract({
-							path: drivePath,
-						});
-						zip.on("extract", () => {
-							this.appManager.ClientToast(ToastLevel.success, "Installed libs");
-						});
-						zip.on("error", () => {
-							this.appManager.ClientToast(
-								ToastLevel.error,
-								"Error extracting libs"
-							);
-						});
-					} catch (error) {
-						console.log("error extracting libs", error);
-						this.appManager.ClientToast(
-							ToastLevel.error,
-							"Error extracting libs"
-						);
-					}
-				},
-			}
-		).catch((error: Error) => {
-			console.log("error downloading libs", error);
-			this.appManager.ClientToast(ToastLevel.error, "Error downloading libs");
-		});
-	}
+                }
+            }
+        } catch (error) {
+            if (!this.fromSplitManager) {
+                this.appManager.SendMiscEvent(ElectronEvents.LostConnectionToBoard, "")
+                this.freshDriveScan()
+            }
 
-	public async DownloadKmk() {
-		download(this.appManager.win, `${programSettings.apiUrl}kmk.zip`, {
-			directory: app.getPath("temp"),
-			filename: "kmk.zip",
-			onCompleted: (file: any) => {
-				this.appManager.ClientToast(ToastLevel.success, "Downloaded KmK");
-			},
-		}).catch((error: Error) => {
-			console.log("Error", error);
-		});
-	}
+        }
+    }
+    async managePingDrive() {
+        if (this.kbDrive !== "") {
+            if (this.interval === undefined) {
+                const intervalTime = 5000
+                const interval = setInterval(() => {
+                    this.pingDrive()
+                }, intervalTime)
+                this.interval = interval
+            }
+        } else {
+            if (!this.isScaning) {
+                await this.scanDrives(true)
+            } else {
+                // await  this.delay(10000)
+                //         this.managePingDrive()
 
-	public async InstallKmk(drivePath: string) {
-		try {
-			const zip = new DecompressZip(this.kmkPath);
-			zip.extract({
-				path: drivePath,
-			});
-			zip.on("extract", () => {
-				this.appManager.ClientToast(ToastLevel.success, "Installed KmK");
-			});
-			zip.on("error", (error: any) => {
-				console.log("error extracting kmk", error);
-				this.appManager.ClientToast(ToastLevel.error, "Error extracting KmK");
-			});
-		} catch (error) {
-			console.log("error extracting kmk", error);
-			this.appManager.ClientToast(ToastLevel.error, "Error extracting KmK");
-		}
-	}
-	public async manageDriveScan() {
-		try {
-			// console.log("ManageDrive")
-			if (
-				!this.didNotFindDrive &&
-				this.hasKeymap !== "" &&
-				this.hasLayout !== ""
-			) {
-				const layoutjson = await fs.readFile(this.hasLayout, "utf8");
-				this.appManager.UpdateLayout(layoutjson);
-				const mainPy = await fs.readFile(this.hasKeymap, "utf8");
-				this.appManager.UpdateKeyMap(mainPy);
-				return;
-			}
-			if (!this.isScaning) {
-				this.isScaning = true;
-				await this.scanDrives();
-				if (this.didNotFindDrive && this.keepLooking) {
-					// console.log("scaning again")
-					if (!this.haveToldClientAboutScaning) {
-						this.appManager.SendMiscEvent(
-							ElectronEvents.ScanAgain,
-							"scaning again"
-						);
-						this.haveToldClientAboutScaning = true;
-					}
-					await this.delay(5000);
-					this.manageDriveScan();
-				}
-			}
-		} catch (error) {
-			console.log("error in scanning again", error, this);
-		}
-		this.managePingDrive();
-	}
-	async readProPlan() {
-		try {
-			const tmpPath = path.join(app.getPath("temp"), "ppp.temp");
-			const data = await fs.readFile(tmpPath, "utf8");
-			this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true);
-		} catch (error) {
-			this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true);
-			console.log("error in reading pro plan", error);
-			return "";
-		}
-	}
+            }
 
-	async setProPlan(id: string) {
-		try {
-			console.log("settings pro plan", id);
-			const data = id;
-			const tmpPath = path.join(app.getPath("temp"), "ppp.temp");
-			const newFile = await fs.writeFile(tmpPath, data, "utf8");
-			this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true);
+        }
+    }
 
-			// console.log("newFile from cache", newFile)
-		} catch (error) {
-			console.log("error in writing pro plan", error);
-		}
-	}
 
-	async readCache(): Promise<string> {
-		try {
-			const tmpPath = path.join(app.getPath("temp"), "peg.temp");
-			const data = await fs.readFile(tmpPath, "utf8");
-			return data;
-		} catch (error) {
-			console.log("error in reading cache data", error);
-			return "";
-		}
-	}
+    public async DownloadAndInstallLib(BoardName: string, drivePath: string) {
+        try {
+            const libDir = path.join(drivePath, "lib")
+            await fs.rm(libDir, { recursive: true });
+            console.log(`${libDir} is deleted!`);
+        } catch (error) {
+            console.log("error removing old libs", error)
+        }
+        download(this.appManager.win, `${programSettings.apiUrl}lib/${BoardName}.zip`, {
+            directory: app.getPath("temp"),
+            filename: `${BoardName}.zip`,
+            onCompleted: (file: any) => {
+                try {
+                    const srcPath = path.join(app.getPath("temp"), `${BoardName}.zip`)
+                    const zip = new DecompressZip(srcPath);
+                    zip.extract({
+                        path: drivePath,
+                    });
+                    zip.on("extract", () => {
+                        this.appManager.ClientToast(ToastLevel.success, "Installed libs")
+                    })
+                    zip.on("error", () => {
+                        this.appManager.ClientToast(ToastLevel.error, "Error extracting libs")
+                    })
 
-	async cacheData(data: string) {
-		try {
-			const tmpPath = path.join(app.getPath("temp"), "peg.temp");
-			const newFile = await fs.writeFile(tmpPath, data, "utf8");
-			// console.log("newFile from cache", newFile)
-		} catch (error) {
-			console.log("error in writing cache data", error);
-		}
-	}
+                } catch (error) {
+                    console.log("error extracting libs", error)
+                    this.appManager.ClientToast(ToastLevel.error, "Error extracting libs")
 
-	async readSettings(event: ElectronEvents, fileName: FileName) {
-		try {
-			const tmpPath = path.join(app.getPath("appData"), fileName);
-			const data = await fs.readFile(tmpPath, "utf8");
-			this.appManager.SendMiscEvent(event, data);
-			console.log("reading Settings", tmpPath);
-		} catch (error) {
-			console.log("error in reading cache data", error);
-			return "";
-		}
-	}
+                }
+            }
+        }).catch((error: Error) => {
+            console.log("error downloading libs", error)
+            this.appManager.ClientToast(ToastLevel.error, "Error downloading libs")
 
-	async saveSettings(data: string, fileName: FileName) {
-		try {
-			const tmpPath = path.join(app.getPath("appData"), fileName);
-			const newFile = await fs.writeFile(tmpPath, data, "utf8");
-			console.log("saving Settings");
-		} catch (error) {
-			console.log("error in writing settings data", error);
-		}
-	}
 
-	public async scanDrives(dontUpdate: boolean = false) {
-		try {
-			// console.log("scanDrives")
-			const disks = await nodeDiskInfo.getDiskInfo();
 
-			for (const disk of disks) {
-				// console.log("disk of disks")
-				if (process.platform !== "win32") {
-					if (!disk.mounted.startsWith("/") || disk.used === 0) {
-						console.log("not messing with ");
-						continue;
-					}
-				}
+        })
 
-				try {
-					// console.log("readdir")
-					const files = await fs.readdir(disk.mounted);
-					if (files.includes("main.py") && files.includes("layout.json")) {
-						this.kbDrive = `${disk.mounted}/`;
-						this.hasKeymap = `${this.kbDrive}main.py`;
-						this.hasLayout = `${this.kbDrive}layout.json`;
-						break;
-					}
-				} catch (error) {
-					console.log("this is not the drive you are looking for", error);
-					continue;
-				}
-			}
-			if (this.kbDrive !== "") {
-				this.didNotFindDrive = false;
-				this.haveToldClientAboutScaning = false;
-				this.fromSplitManager = false;
-				let tempData: any = { kbDrive: this.kbDrive };
 
-				if (this.hasKeymap !== "") {
-					const mainPy = await fs.readFile(this.hasKeymap, "utf8");
-					if (!dontUpdate) {
-						this.appManager.UpdateKeyMap(mainPy);
-					}
+    }
 
-					tempData["hasKeymap"] = this.hasKeymap;
-				}
-				if (this.hasLayout !== "") {
-					const layoutjson = await fs.readFile(this.hasLayout, "utf8");
-					if (!dontUpdate) {
-						this.appManager.UpdateLayout(layoutjson);
-					}
-					tempData["hasLayout"] = this.hasLayout;
-				}
-				this.cacheData(JSON.stringify(tempData));
-			} else {
-				this.didNotFindDrive = true;
-				this.isScaning = false;
-			}
-		} catch (err) {
-			console.error("err in  scanDrives: ", err);
-		}
-	}
+    public async DownloadKmk() {
+        download(this.appManager.win, `${programSettings.apiUrl}kmk.zip`, {
+            directory: app.getPath("temp"),
+            filename: "kmk.zip",
+            onCompleted: (file: any) => {
+                this.appManager.ClientToast(ToastLevel.success, "Downloaded KmK")
+            }
 
-	public async saveFile(newMap: string, retry: boolean = false) {
-		try {
-			if (this.kbDrive !== "") {
-				if (this.hasKeymap !== "") {
-					const newFile = await fs.writeFile(this.hasKeymap, newMap, "utf8");
-					this.appManager.SendMiscEvent(ElectronEvents.MapSaved, "");
-					console.log("newFile from save", newFile);
-				}
-			} else {
-				if (!retry) {
-					await this.loadFromCacheIfCan();
-					this.saveFile(newMap, true);
-				} else {
-					await this.scanDrives(true);
-					this.saveFile(newMap, true);
-				}
-				//todo alaert user map did not update
-				console.log("dont have the needed stuff");
-			}
-		} catch (error) {
-			console.log("error in writing map", error);
-			this.appManager.ClientToast(ToastLevel.error, `Error in saving map.`);
+        }).catch((error: Error) => { console.log("Error", error) })
+    }
 
-			//todo alaert user map did not update
-		}
-	}
 
-	public async writeData(data: { fileData: string; path: string[] }) {
-		try {
-			const writepath = path.join(...data.path);
-			const newFile = await fs.writeFile(writepath, data.fileData, "utf8");
-			console.log("force write data");
-			if (data.path[1] === FileName.main) {
-				const codePyPath = path.join(data.path[0], "code.py");
-				const files = await fs.readdir(data.path[0]);
-				if (files.includes("code.py")) {
-					console.log("removing code.py");
-					fs.unlink(codePyPath);
-				}
-			} else {
-				this.appManager.ClientToast(
-					ToastLevel.success,
-					`${data.path[1]} Saved`
-				);
-			}
-		} catch (error) {
-			this.appManager.ClientToast(
-				ToastLevel.error,
-				`Error when saving ${path.join("/")}`
-			);
-			console.log("error in writing map", error);
-			//todo alaert user map did not update
-		}
-	}
 
-	public async wrightOledBmp(
-		fileData: number[][],
-		fileNumber: number | string,
-		retry: boolean = false
-	) {
-		try {
-			if (this.kbDrive !== "") {
-				let bitmap = new bitmapManipulation.BMPBitmap(128, 32, 1);
-				fileData.forEach((row, i) => {
-					row.forEach((pxl, ii) => {
-						if (pxl === 1) {
-							bitmap.setPixel(ii, i, 0xff);
-						}
-					});
-				});
-				bitmap.save(`${this.kbDrive}/${fileNumber}.bmp`);
-			} else {
-				if (!retry) {
-					await this.loadFromCacheIfCan();
-					this.wrightOledBmp(fileData, fileNumber, true);
-				} else {
-					await this.scanDrives(true);
-					this.wrightOledBmp(fileData, fileNumber, true);
-				}
-				//todo alaert user map did not update
-				console.log("dont have the needed stuff");
-				// console.log("missing kb drive", this)
-			}
-		} catch (error) {
-			console.log("error in writing map", error);
+    public async InstallKmk(drivePath: string) {
+        try {
+            const zip = new DecompressZip(this.kmkPath);
+            zip.extract({
+                path: drivePath,
+            });
+            zip.on("extract", () => {
+                this.appManager.ClientToast(ToastLevel.success, "Installed KmK")
+            })
+            zip.on("error", (error: any) => {
+                console.log("error extracting kmk", error)
+                this.appManager.ClientToast(ToastLevel.error, "Error extracting KmK")
+            })
+        } catch (error) {
+            console.log("error extracting kmk", error)
+            this.appManager.ClientToast(ToastLevel.error, "Error extracting KmK")
+        }
 
-			//todo alaert user map did not update
-		}
-	}
+    }
+    public async manageDriveScan() {
+        try {
+            // console.log("ManageDrive")
+            if (!this.didNotFindDrive && this.hasKeymap !== "" && this.hasLayout !== "") {
+                const layoutjson = await fs.readFile(this.hasLayout, 'utf8');
+                this.appManager.UpdateLayout(layoutjson)
+                const mainPy = await fs.readFile(this.hasKeymap, 'utf8');
+                this.appManager.UpdateKeyMap(mainPy)
+                return
+            }
+            if (!this.isScaning) {
+                this.isScaning = true
+                await this.scanDrives()
+                if (this.didNotFindDrive && this.keepLooking) {
+                    // console.log("scaning again")
+                    if (!this.haveToldClientAboutScaning) {
+                        this.appManager.SendMiscEvent(ElectronEvents.ScanAgain, "scaning again")
+                        this.haveToldClientAboutScaning = true
+                    }
+                    await this.delay(5000)
+                    this.manageDriveScan()
+                }
+            }
 
-	public async readOledBmp(
-		fileNumber: number | string,
-		retry: boolean = false
-	) {
-		console.log("drive letter", this.kbDrive);
-		if (this.kbDrive !== "") {
-			console.log(
-				" I got to look for a bmp by the number of ",
-				this,
-				fileNumber,
-				`${this.kbDrive}${fileNumber}.bmp`
-			);
-			let data = [];
-			let oldFile = bitmapManipulation.BMPBitmap.fromFile(
-				`${this.kbDrive}${fileNumber}.bmp`
-			);
-			for (let row = 0; row < 32; row++) {
-				let tempRow = [];
-				for (let col = 0; col < 128; col++) {
-					const value = oldFile.getPixel(col, row);
-					tempRow.push(value === 255 ? 1 : 0);
-				}
-				data.push(tempRow);
-			}
-			this.appManager.UpdateOled(data, fileNumber);
-		} else {
-			if (!retry) {
-				await this.loadFromCacheIfCan();
-				this.readOledBmp(fileNumber, true);
-			} else {
-				await this.scanDrives(true);
-				this.readOledBmp(fileNumber, true);
-			}
-			//todo alaert user map did not update
-			console.log("dont have the needed stuff");
-			console.log("missing kb drive", this);
-		}
-	}
+        } catch (error) {
+            console.log("error in scanning again", error, this)
+        }
+        this.managePingDrive()
+
+    }
+    async readProPlan() {
+        try {
+            const tmpPath = path.join(app.getPath("temp"), 'ppp.temp')
+            const data = await fs.readFile(tmpPath, 'utf8');
+            this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true)
+
+        } catch (error) {
+            this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true)
+            console.log("error in reading pro plan", error)
+            return ""
+        }
+    }
+
+    async setProPlan(id: string) {
+        try {
+
+            console.log("settings pro plan", id)
+            const data = id
+            const tmpPath = path.join(app.getPath("temp"), 'ppp.temp')
+            const newFile = await fs.writeFile(tmpPath, data, 'utf8');
+            this.appManager.SendMiscEvent(ElectronEvents.IsProPlan, true)
+
+            // console.log("newFile from cache", newFile)
+        } catch (error) {
+            console.log("error in writing pro plan", error)
+        }
+    }
+
+    async readCache(): Promise<string> {
+        try {
+            const tmpPath = path.join(app.getPath("temp"), 'peg.temp')
+            const data = await fs.readFile(tmpPath, 'utf8');
+            return data
+
+        } catch (error) {
+            console.log("error in reading cache data", error)
+            return ""
+        }
+    }
+
+    async cacheData(data: string) {
+        try {
+            const tmpPath = path.join(app.getPath("temp"), 'peg.temp')
+            const newFile = await fs.writeFile(tmpPath, data, 'utf8');
+            // console.log("newFile from cache", newFile)
+        } catch (error) {
+            console.log("error in writing cache data", error)
+        }
+    }
+
+    async readSettings(event: ElectronEvents, fileName: FileName) {
+        try {
+            const tmpPath = path.join(app.getPath("appData"), fileName)
+            const data = await fs.readFile(tmpPath, 'utf8');
+            this.appManager.SendMiscEvent(event, data)
+            console.log("reading Settings", tmpPath)
+
+        } catch (error) {
+            console.log("error in reading cache data", error)
+            return ""
+        }
+    }
+
+    async saveSettings(data: string, fileName: FileName) {
+        try {
+            const tmpPath = path.join(app.getPath("appData"), fileName)
+            const newFile = await fs.writeFile(tmpPath, data, 'utf8');
+            console.log("saving Settings")
+        } catch (error) {
+            console.log("error in writing settings data", error)
+        }
+
+    }
+
+    public async scanDrives(dontUpdate: boolean = false) {
+        try {
+            // console.log("scanDrives")
+            const disks = await nodeDiskInfo.getDiskInfo()
+
+            for (const disk of disks) {
+                // console.log("disk of disks")
+                if (process.platform !== "win32") {
+                    if (!disk.mounted.startsWith("/") || disk.used === 0) {
+                        console.log("not messing with ")
+                        continue
+                    }
+                }
+
+                try {
+                    // console.log("readdir")
+                    const files = await fs.readdir(disk.mounted);
+                    if (files.includes("main.py") && files.includes("layout.json")) {
+                        this.kbDrive = `${disk.mounted}/`;
+                        this.hasKeymap = `${this.kbDrive}main.py`
+                        this.hasLayout = `${this.kbDrive}layout.json`
+                        break
+                    }
+                } catch (error) {
+                    console.log("this is not the drive you are looking for", error)
+                    continue
+                }
+
+            }
+            if (this.kbDrive !== "") {
+                this.didNotFindDrive = false;
+                this.haveToldClientAboutScaning = false
+                this.fromSplitManager = false
+                let tempData: any = { kbDrive: this.kbDrive }
+
+                if (this.hasKeymap !== "") {
+                    const mainPy = await fs.readFile(this.hasKeymap, 'utf8');
+                    if (!dontUpdate) {
+                        this.appManager.UpdateKeyMap(mainPy)
+                    }
+
+                    tempData["hasKeymap"] = this.hasKeymap
+                }
+                if (this.hasLayout !== "") {
+                    const layoutjson = await fs.readFile(this.hasLayout, 'utf8');
+                    if (!dontUpdate) {
+                        this.appManager.UpdateLayout(layoutjson)
+                    }
+                    tempData["hasLayout"] = this.hasLayout
+                }
+                this.cacheData(JSON.stringify(tempData))
+            }
+            else {
+                this.didNotFindDrive = true;
+                this.isScaning = false
+
+            }
+
+        } catch (err) {
+            console.error("err in  scanDrives: ", err);
+        }
+
+    }
+
+    public async saveFile(newMap: string, retry: boolean = false) {
+        try {
+            if (this.kbDrive !== "") {
+                if (this.hasKeymap !== "") {
+                    const newFile = await fs.writeFile(this.hasKeymap, newMap, 'utf8');
+                    this.appManager.SendMiscEvent(ElectronEvents.MapSaved, "")
+                    console.log("newFile from save", newFile)
+                }
+            }
+            else {
+                if (!retry) {
+                    await this.loadFromCacheIfCan()
+                    this.saveFile(newMap, true)
+                } else {
+                    await this.scanDrives(true)
+                    this.saveFile(newMap, true)
+
+                }
+                //todo alaert user map did not update
+                console.log("dont have the needed stuff")
+
+            }
+        } catch (error) {
+            console.log("error in writing map", error)
+            this.appManager.ClientToast(ToastLevel.error, `Error in saving map.`)
+
+            //todo alaert user map did not update
+        }
+
+    }
+
+    public async writeData(data: { fileData: string, path: string[] }) {
+        try {
+            const writepath = path.join(...data.path)
+            const newFile = await fs.writeFile(writepath, data.fileData, 'utf8');
+            console.log("force write data")
+            if (data.path[1] === FileName.main) {
+                const codePyPath = path.join(data.path[0], "code.py")
+                const files = await fs.readdir(data.path[0]);
+                if (files.includes("code.py")) {
+                    console.log("removing code.py")
+                    fs.unlink(codePyPath)
+                }
+            } else {
+                this.appManager.ClientToast(ToastLevel.success, `${data.path[1]} Saved`)
+            }
+        } catch (error) {
+            this.appManager.ClientToast(ToastLevel.error, `Error when saving ${path.join("/")}`)
+            console.log("error in writing map", error)
+            //todo alaert user map did not update
+        }
+
+    }
+
+    public async wrightOledBmp(fileData: number[][], fileNumber: number | string, retry: boolean = false) {
+        try {
+            if (this.kbDrive !== "") {
+
+                let bitmap = new bitmapManipulation.BMPBitmap(128, 32, 1);
+                fileData.forEach((row, i) => {
+                    row.forEach((pxl, ii) => {
+                        if (pxl === 1) {
+                            bitmap.setPixel(ii, i, 0xff)
+                        }
+                    })
+                })
+                bitmap.save(`${this.kbDrive}/${fileNumber}.bmp`);
+            } else {
+                if (!retry) {
+                    await this.loadFromCacheIfCan()
+                    this.wrightOledBmp(fileData, fileNumber, true)
+                } else {
+                    await this.scanDrives(true)
+                    this.wrightOledBmp(fileData, fileNumber, true)
+                }
+                //todo alaert user map did not update
+                console.log("dont have the needed stuff")
+                // console.log("missing kb drive", this)
+            }
+        } catch (error) {
+            console.log("error in writing map", error)
+
+            //todo alaert user map did not update
+        }
+    }
+
+    public async readOledBmp(fileNumber: number | string, retry: boolean = false) {
+        console.log("drive letter", this.kbDrive)
+        if (this.kbDrive !== "") {
+            console.log(" I got to look for a bmp by the number of ", this, fileNumber, `${this.kbDrive}${fileNumber}.bmp`)
+            let data = []
+            let oldFile = bitmapManipulation.BMPBitmap.fromFile(`${this.kbDrive}${fileNumber}.bmp`)
+            for (let row = 0; row < 32; row++) {
+                let tempRow = []
+                for (let col = 0; col < 128; col++) {
+                    const value = oldFile.getPixel(col, row)
+                    tempRow.push(value === 255 ? 1 : 0)
+                }
+                data.push(tempRow)
+            }
+            this.appManager.UpdateOled(data, fileNumber)
+        } else {
+            if (!retry) {
+                await this.loadFromCacheIfCan()
+                this.readOledBmp(fileNumber, true)
+            } else {
+                await this.scanDrives(true)
+                this.readOledBmp(fileNumber, true)
+            }
+            //todo alaert user map did not update
+            console.log("dont have the needed stuff")
+            console.log("missing kb drive", this)
+        }
+
+    }
 }

--- a/src/logic/diskManager.ts
+++ b/src/logic/diskManager.ts
@@ -505,4 +505,22 @@ export class DiskManager {
         }
 
     }
+    public async createTempKeymap() {
+        
+        if(this.hasKeymap !== ""){
+            const mainPy = await fs.readFile(this.hasKeymap, 'utf8');
+
+            try{
+                const tempKeymap = await fs.access(path.join(app.getPath("temp"), "tempKeymap.py"));
+                console.log("found temp keymap")
+                await fs.unlink(path.join(app.getPath("temp"), "tempKeymap.py"))
+                console.log("deleted temp keymap")
+                await fs.writeFile(path.join(app.getPath("temp"), "tempKeymap.py"), mainPy)
+                console.log("created temp keymap")
+            } catch (error) {
+                console.log("no temp keymap found")
+                await fs.writeFile(path.join(app.getPath("temp"), "tempKeymap.py"), mainPy)
+            }
+        }
+    }
 }

--- a/src/logic/diskManager.ts
+++ b/src/logic/diskManager.ts
@@ -95,9 +95,6 @@ export class DiskManager {
         }
         return change
     }
-    public getDrivePath(): string {
-		return this.kbDrive;
-	}
     async pingDrive() {
         try {
             const files = await fs.readdir(this.kbDrive);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,190 +1,188 @@
-export type SingleUsableKey = {
-
-}
+export type SingleUsableKey = {};
 
 export interface KeyCode {
-    code: string;
-    display: string;
-    keybinding: string;
-    canHaveSub: boolean;
-    canHaveSubNumber: boolean;
-    subNumber: number;
-    Description: string;
-    subOne?: KeyCode;
-    subTwo?: KeyCode;
+	code: string;
+	display: string;
+	keybinding: string;
+	canHaveSub: boolean;
+	canHaveSubNumber: boolean;
+	subNumber: number;
+	Description: string;
+	subOne?: KeyCode;
+	subTwo?: KeyCode;
 }
 export interface LayoutFeatures {
-    perkey: boolean;
-    oled: boolean;
-    ble: boolean;
-    underglow: boolean;
-    name: string;
-    creator: string;
-    perkeyCount: number;
-    underglowCount: number;
-    split: boolean;
-    rightSide: boolean;
-    encoders: boolean;
-    encoderCount: number;
-    rx_tx: boolean
-    uartFlip: boolean
-    splitPico: boolean
-    bootSize: number
+	perkey: boolean;
+	oled: boolean;
+	ble: boolean;
+	underglow: boolean;
+	name: string;
+	creator: string;
+	perkeyCount: number;
+	underglowCount: number;
+	split: boolean;
+	rightSide: boolean;
+	encoders: boolean;
+	encoderCount: number;
+	rx_tx: boolean;
+	uartFlip: boolean;
+	splitPico: boolean;
+	bootSize: number;
 }
 export interface LayoutKey {
-    x: number;
-    y: number;
-    w: number;
-    h: number;
+	x: number;
+	y: number;
+	w: number;
+	h: number;
 }
 export interface Layout {
-    features: LayoutFeatures;
-    layout: LayoutKey[];
-    underglow: LayoutKey[];
+	features: LayoutFeatures;
+	layout: LayoutKey[];
+	underglow: LayoutKey[];
 }
-export type OledPixel = { x: number, y: number }
-export type ToastMessage = { message: string, toastLevel: ToastLevel, id: string }
+export type OledPixel = { x: number; y: number };
+export type ToastMessage = {
+	message: string;
+	toastLevel: ToastLevel;
+	id: string;
+};
 export interface OledTextSection {
-    0: OledReactionType,
-    1: string[]
+	0: OledReactionType;
+	1: string[];
 }
 export interface FeatureResponse {
-    _id: string;
-    description: string;
-    featureType: ShareableFeatureType
-    author: string,
-    keyboard: string;
-    path: string;
-    title: string;
-    universal: boolean
-    version: string
-    code?: any
-    downloads: number
-
+	_id: string;
+	description: string;
+	featureType: ShareableFeatureType;
+	author: string;
+	keyboard: string;
+	path: string;
+	title: string;
+	universal: boolean;
+	version: string;
+	code?: any;
+	downloads: number;
 }
 export enum OledDisplayType {
-    image = "IMG",
-    text = "TXT"
+	image = "IMG",
+	text = "TXT",
 }
 export enum OledReactionType {
-    static = "STATIC",
-    layer = "LAYER"
+	static = "STATIC",
+	layer = "LAYER",
 }
-
 
 export enum FileName {
-    main = "main.py",
-    kb = "kb.py",
-    layout = "layout.json",
-    settings = "settings.json",
-    customCodes = "customCodes.json",
-    boot = "boot.py"
+	main = "main.py",
+	kb = "kb.py",
+	layout = "layout.json",
+	settings = "settings.json",
+	customCodes = "customCodes.json",
+	boot = "boot.py",
 }
 export enum ShareableFeatureType {
-    keyCodes = "keycodes",
-    keyMaps = "keyMaps",
-    ledMaps = "ledMaps",
-    oleds = "oleds",
-    codeBlocks = "codeBlocks"
+	keyCodes = "keycodes",
+	keyMaps = "keyMaps",
+	ledMaps = "ledMaps",
+	oleds = "oleds",
+	codeBlocks = "codeBlocks",
 }
 
 export enum ElectronEvents {
-    UpdateLayout = "UpdateLayout",
-    UpdateKeyMap = "UpdateKeyMap",
-    UpdateOled = "UpdateOled",
-    Scan = "Scan",
-    SaveMap = "SaveMap",
-    Savefile = "Savefile",
-    SaveOled = "SaveOled",
-    ReadOled = "ReadOled",
-    MapSaved = "MapSaved",
-    FilePicker = "FilePicker",
-    FilePickerClose = "FilePickerClose",
-    DownLoadKmk = "DownLoadKmk",
-    DownLoadAndInstallLib = "DownLoadAndInstallLib",
-    InstallKmk = "InstallKmk",
-    ScanAgain = "ScanAgain",
-    FreshDriveScan = "FreshDriveScan",
-    ReadSettings = "ReadSettings",
-    ReadCustomCodes = "ReadCustomCodes",
-    SaveSettings = "SaveSettings",
-    SaveCustomCodes = "SaveCustomCodes",
-    SetProPlan = "SetProPlan",
-    IsProPlan = "IsProPlan",
-    WindowClose = "WindowClose",
-    WindowFullScreen = "WindowFullScreen",
-    WindowMinimize = "WindowMinimize",
-    BoardChange = "BoardChange",
-    LostConnectionToBoard = "LostConnectionToBoard",
-    ClientUp = "ClientUp",
-    Toast = "Toast",
-    Misc = "Misc"
-
+	UpdateLayout = "UpdateLayout",
+	UpdateKeyMap = "UpdateKeyMap",
+	UpdateOled = "UpdateOled",
+	Scan = "Scan",
+	SaveMap = "SaveMap",
+	Savefile = "Savefile",
+	SaveOled = "SaveOled",
+	ReadOled = "ReadOled",
+	MapSaved = "MapSaved",
+	FilePicker = "FilePicker",
+	FilePickerClose = "FilePickerClose",
+	DownLoadKmk = "DownLoadKmk",
+	DownLoadAndInstallLib = "DownLoadAndInstallLib",
+	InstallKmk = "InstallKmk",
+	ScanAgain = "ScanAgain",
+	FreshDriveScan = "FreshDriveScan",
+	ReadSettings = "ReadSettings",
+	ReadCustomCodes = "ReadCustomCodes",
+	SaveSettings = "SaveSettings",
+	SaveCustomCodes = "SaveCustomCodes",
+	SetProPlan = "SetProPlan",
+	IsProPlan = "IsProPlan",
+	WindowClose = "WindowClose",
+	WindowFullScreen = "WindowFullScreen",
+	WindowMinimize = "WindowMinimize",
+	BoardChange = "BoardChange",
+	LostConnectionToBoard = "LostConnectionToBoard",
+	ClientUp = "ClientUp",
+	Toast = "Toast",
+	Misc = "Misc",
+	OpenFile = "OpenFile",
 }
 export enum ScrollerSides {
-    Right = "right",
-    Left = "left",
-    Top = "top",
-    Bottom = "bottom"
-
+	Right = "right",
+	Left = "left",
+	Top = "top",
+	Bottom = "bottom",
 }
 export enum ScrollerDirection {
-    Vertical = "vertical",
-    Horizontal = "horizontal"
+	Vertical = "vertical",
+	Horizontal = "horizontal",
 }
 export enum SplitFlashStage {
-    MainSide,
-    Unplugged,
-    OffSide,
-    Finished
+	MainSide,
+	Unplugged,
+	OffSide,
+	Finished,
 }
 export enum ModalDefault {
-    None,
-    SplitFlashManager
+	None,
+	SplitFlashManager,
 }
 export enum ToastLevel {
-    info,
-    error,
-    warn,
-    success,
-    debug,
+	info,
+	error,
+	warn,
+	success,
+	debug,
 }
-
 
 export enum NotificationColor {
-    Green = 'green',
-    Yellow = 'yellow',
-    Red = 'red',
-    Blue = 'blue',
+	Green = "green",
+	Yellow = "yellow",
+	Red = "red",
+	Blue = "blue",
 }
 export enum Theme {
-    light = "light",
-    dark = "dark",
-    cupcake = "cupcake",
-    bumblebee = "bumblebee",
-    emerald = "emerald",
-    corporate = "corporate",
-    synthwave = "synthwave",
-    retro = "retro",
-    cyberpunk = "cyberpunk",
-    valentine = "valentine",
-    halloween = "halloween",
-    garden = "garden",
-    forest = "forest",
-    aqua = "aqua",
-    lofi = "lofi",
-    pastel = "pastel",
-    fantasy = "fantasy",
-    wireframe = "wireframe",
-    black = "black",
-    luxury = "luxury",
-    dracula = "dracula",
-    cmyk = "cmyk",
-    autumn = "autumn",
-    business = "business",
-    acid = "acid",
-    lemonade = "lemonade",
-    night = "night",
-    coffee = "coffee",
-    winter = "winter"
+	light = "light",
+	dark = "dark",
+	cupcake = "cupcake",
+	bumblebee = "bumblebee",
+	emerald = "emerald",
+	corporate = "corporate",
+	synthwave = "synthwave",
+	retro = "retro",
+	cyberpunk = "cyberpunk",
+	valentine = "valentine",
+	halloween = "halloween",
+	garden = "garden",
+	forest = "forest",
+	aqua = "aqua",
+	lofi = "lofi",
+	pastel = "pastel",
+	fantasy = "fantasy",
+	wireframe = "wireframe",
+	black = "black",
+	luxury = "luxury",
+	dracula = "dracula",
+	cmyk = "cmyk",
+	autumn = "autumn",
+	business = "business",
+	acid = "acid",
+	lemonade = "lemonade",
+	night = "night",
+	coffee = "coffee",
+	winter = "winter",
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,188 +1,191 @@
-export type SingleUsableKey = {};
+export type SingleUsableKey = {
+
+}
 
 export interface KeyCode {
-	code: string;
-	display: string;
-	keybinding: string;
-	canHaveSub: boolean;
-	canHaveSubNumber: boolean;
-	subNumber: number;
-	Description: string;
-	subOne?: KeyCode;
-	subTwo?: KeyCode;
+    code: string;
+    display: string;
+    keybinding: string;
+    canHaveSub: boolean;
+    canHaveSubNumber: boolean;
+    subNumber: number;
+    Description: string;
+    subOne?: KeyCode;
+    subTwo?: KeyCode;
 }
 export interface LayoutFeatures {
-	perkey: boolean;
-	oled: boolean;
-	ble: boolean;
-	underglow: boolean;
-	name: string;
-	creator: string;
-	perkeyCount: number;
-	underglowCount: number;
-	split: boolean;
-	rightSide: boolean;
-	encoders: boolean;
-	encoderCount: number;
-	rx_tx: boolean;
-	uartFlip: boolean;
-	splitPico: boolean;
-	bootSize: number;
+    perkey: boolean;
+    oled: boolean;
+    ble: boolean;
+    underglow: boolean;
+    name: string;
+    creator: string;
+    perkeyCount: number;
+    underglowCount: number;
+    split: boolean;
+    rightSide: boolean;
+    encoders: boolean;
+    encoderCount: number;
+    rx_tx: boolean
+    uartFlip: boolean
+    splitPico: boolean
+    bootSize: number
 }
 export interface LayoutKey {
-	x: number;
-	y: number;
-	w: number;
-	h: number;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
 }
 export interface Layout {
-	features: LayoutFeatures;
-	layout: LayoutKey[];
-	underglow: LayoutKey[];
+    features: LayoutFeatures;
+    layout: LayoutKey[];
+    underglow: LayoutKey[];
 }
-export type OledPixel = { x: number; y: number };
-export type ToastMessage = {
-	message: string;
-	toastLevel: ToastLevel;
-	id: string;
-};
+export type OledPixel = { x: number, y: number }
+export type ToastMessage = { message: string, toastLevel: ToastLevel, id: string }
 export interface OledTextSection {
-	0: OledReactionType;
-	1: string[];
+    0: OledReactionType,
+    1: string[]
 }
 export interface FeatureResponse {
-	_id: string;
-	description: string;
-	featureType: ShareableFeatureType;
-	author: string;
-	keyboard: string;
-	path: string;
-	title: string;
-	universal: boolean;
-	version: string;
-	code?: any;
-	downloads: number;
+    _id: string;
+    description: string;
+    featureType: ShareableFeatureType
+    author: string,
+    keyboard: string;
+    path: string;
+    title: string;
+    universal: boolean
+    version: string
+    code?: any
+    downloads: number
+
 }
 export enum OledDisplayType {
-	image = "IMG",
-	text = "TXT",
+    image = "IMG",
+    text = "TXT"
 }
 export enum OledReactionType {
-	static = "STATIC",
-	layer = "LAYER",
+    static = "STATIC",
+    layer = "LAYER"
 }
 
+
 export enum FileName {
-	main = "main.py",
-	kb = "kb.py",
-	layout = "layout.json",
-	settings = "settings.json",
-	customCodes = "customCodes.json",
-	boot = "boot.py",
+    main = "main.py",
+    kb = "kb.py",
+    layout = "layout.json",
+    settings = "settings.json",
+    customCodes = "customCodes.json",
+    boot = "boot.py"
 }
 export enum ShareableFeatureType {
-	keyCodes = "keycodes",
-	keyMaps = "keyMaps",
-	ledMaps = "ledMaps",
-	oleds = "oleds",
-	codeBlocks = "codeBlocks",
+    keyCodes = "keycodes",
+    keyMaps = "keyMaps",
+    ledMaps = "ledMaps",
+    oleds = "oleds",
+    codeBlocks = "codeBlocks"
 }
 
 export enum ElectronEvents {
-	UpdateLayout = "UpdateLayout",
-	UpdateKeyMap = "UpdateKeyMap",
-	UpdateOled = "UpdateOled",
-	Scan = "Scan",
-	SaveMap = "SaveMap",
-	Savefile = "Savefile",
-	SaveOled = "SaveOled",
-	ReadOled = "ReadOled",
-	MapSaved = "MapSaved",
-	FilePicker = "FilePicker",
-	FilePickerClose = "FilePickerClose",
-	DownLoadKmk = "DownLoadKmk",
-	DownLoadAndInstallLib = "DownLoadAndInstallLib",
-	InstallKmk = "InstallKmk",
-	ScanAgain = "ScanAgain",
-	FreshDriveScan = "FreshDriveScan",
-	ReadSettings = "ReadSettings",
-	ReadCustomCodes = "ReadCustomCodes",
-	SaveSettings = "SaveSettings",
-	SaveCustomCodes = "SaveCustomCodes",
-	SetProPlan = "SetProPlan",
-	IsProPlan = "IsProPlan",
-	WindowClose = "WindowClose",
-	WindowFullScreen = "WindowFullScreen",
-	WindowMinimize = "WindowMinimize",
-	BoardChange = "BoardChange",
-	LostConnectionToBoard = "LostConnectionToBoard",
-	ClientUp = "ClientUp",
-	Toast = "Toast",
-	Misc = "Misc",
-	OpenFile = "OpenFile",
+    UpdateLayout = "UpdateLayout",
+    UpdateKeyMap = "UpdateKeyMap",
+    UpdateOled = "UpdateOled",
+    Scan = "Scan",
+    SaveMap = "SaveMap",
+    Savefile = "Savefile",
+    SaveOled = "SaveOled",
+    ReadOled = "ReadOled",
+    MapSaved = "MapSaved",
+    FilePicker = "FilePicker",
+    FilePickerClose = "FilePickerClose",
+    DownLoadKmk = "DownLoadKmk",
+    DownLoadAndInstallLib = "DownLoadAndInstallLib",
+    InstallKmk = "InstallKmk",
+    ScanAgain = "ScanAgain",
+    FreshDriveScan = "FreshDriveScan",
+    ReadSettings = "ReadSettings",
+    ReadCustomCodes = "ReadCustomCodes",
+    SaveSettings = "SaveSettings",
+    SaveCustomCodes = "SaveCustomCodes",
+    SetProPlan = "SetProPlan",
+    IsProPlan = "IsProPlan",
+    WindowClose = "WindowClose",
+    WindowFullScreen = "WindowFullScreen",
+    WindowMinimize = "WindowMinimize",
+    BoardChange = "BoardChange",
+    LostConnectionToBoard = "LostConnectionToBoard",
+    ClientUp = "ClientUp",
+    Toast = "Toast",
+    Misc = "Misc",
+    OpenFile = "OpenFile",
+
 }
 export enum ScrollerSides {
-	Right = "right",
-	Left = "left",
-	Top = "top",
-	Bottom = "bottom",
+    Right = "right",
+    Left = "left",
+    Top = "top",
+    Bottom = "bottom"
+
 }
 export enum ScrollerDirection {
-	Vertical = "vertical",
-	Horizontal = "horizontal",
+    Vertical = "vertical",
+    Horizontal = "horizontal"
 }
 export enum SplitFlashStage {
-	MainSide,
-	Unplugged,
-	OffSide,
-	Finished,
+    MainSide,
+    Unplugged,
+    OffSide,
+    Finished
 }
 export enum ModalDefault {
-	None,
-	SplitFlashManager,
+    None,
+    SplitFlashManager
 }
 export enum ToastLevel {
-	info,
-	error,
-	warn,
-	success,
-	debug,
+    info,
+    error,
+    warn,
+    success,
+    debug,
 }
 
+
 export enum NotificationColor {
-	Green = "green",
-	Yellow = "yellow",
-	Red = "red",
-	Blue = "blue",
+    Green = 'green',
+    Yellow = 'yellow',
+    Red = 'red',
+    Blue = 'blue',
 }
 export enum Theme {
-	light = "light",
-	dark = "dark",
-	cupcake = "cupcake",
-	bumblebee = "bumblebee",
-	emerald = "emerald",
-	corporate = "corporate",
-	synthwave = "synthwave",
-	retro = "retro",
-	cyberpunk = "cyberpunk",
-	valentine = "valentine",
-	halloween = "halloween",
-	garden = "garden",
-	forest = "forest",
-	aqua = "aqua",
-	lofi = "lofi",
-	pastel = "pastel",
-	fantasy = "fantasy",
-	wireframe = "wireframe",
-	black = "black",
-	luxury = "luxury",
-	dracula = "dracula",
-	cmyk = "cmyk",
-	autumn = "autumn",
-	business = "business",
-	acid = "acid",
-	lemonade = "lemonade",
-	night = "night",
-	coffee = "coffee",
-	winter = "winter",
+    light = "light",
+    dark = "dark",
+    cupcake = "cupcake",
+    bumblebee = "bumblebee",
+    emerald = "emerald",
+    corporate = "corporate",
+    synthwave = "synthwave",
+    retro = "retro",
+    cyberpunk = "cyberpunk",
+    valentine = "valentine",
+    halloween = "halloween",
+    garden = "garden",
+    forest = "forest",
+    aqua = "aqua",
+    lofi = "lofi",
+    pastel = "pastel",
+    fantasy = "fantasy",
+    wireframe = "wireframe",
+    black = "black",
+    luxury = "luxury",
+    dracula = "dracula",
+    cmyk = "cmyk",
+    autumn = "autumn",
+    business = "business",
+    acid = "acid",
+    lemonade = "lemonade",
+    night = "night",
+    coffee = "coffee",
+    winter = "winter"
 }

--- a/src/views/codeBlock/codeBlock.tsx
+++ b/src/views/codeBlock/codeBlock.tsx
@@ -1,101 +1,83 @@
-import { createSignal, For, onCleanup, Show } from "solid-js";
-import DownloadFeature from "../../components/downloadFeature/downloadFeature";
-import MainView from "../../components/mainView/mainView";
-import ShareFeature from "../../components/shareFeature/shareFeature";
-import { KeyMap } from "../../logic/keymapManager";
-import { ElectronEvents, ShareableFeatureType } from "../../types/types";
-import Button from "../../components/button/button";
-import { ClientManager } from "../../logic/clientManager";
-const clientManager = ClientManager.getInstance();
-const keymap = KeyMap.getInstance();
+import { createSignal, For, onCleanup, Show } from 'solid-js'
+import DownloadFeature from '../../components/downloadFeature/downloadFeature'
+import MainView from '../../components/mainView/mainView'
+import ShareFeature from '../../components/shareFeature/shareFeature'
+import { KeyMap } from '../../logic/keymapManager'
+import { ShareableFeatureType, ElectronEvents } from '../../types/types'
+import Button from '../../components/button/button'
+import { ClientManager } from '../../logic/clientManager'
+const clientManager = ClientManager.getInstance()
+const keymap = KeyMap.getInstance()
 
 export default function LED() {
-	const [codeBlocks, setCodeBlock] = createSignal(keymap.codeBlock);
+    const [codeBlocks, setCodeBlock] = createSignal(keymap.codeBlock)
 
-	const subId2 = keymap.Subscribe(() => {
-		setCodeBlock(keymap.codeBlock);
-	});
+    const subId2 = keymap.Subscribe(() => {
+        setCodeBlock(keymap.codeBlock)
+    })
 
-	onCleanup(() => {
-		keymap.Unsubscribe(subId2);
-	});
-	const fallBack = () => {
-		return (
-			<div>
-				<p>
-					Your keyboard does not have a code block currently. Download one with
-					the button below or wrap any code in "# codeblock"
-				</p>
-				<Button
+    onCleanup(() => {
+
+        keymap.Unsubscribe(subId2)
+    })
+    const fallBack = () => {
+        return (
+            <div>
+                <p>
+                    Your keyboard does not have a code block currently. Download one with the button below or wrap any code in "# codeblock"
+                </p>
+                <Button
 					onClick={() => {
 						clientManager.sendToBackend(ElectronEvents.OpenFile, "");
 					}}
 				>
 					Add Code Blocks
 				</Button>
-			</div>
-		);
-	};
-	console.log("code blocks length", codeBlocks.length);
-	return (
-		<MainView
-			title="Code Blocks"
-			description={`A code block is a way for you to run some custom code and keep it around. 
+            </div>
+            
+
+        )
+    }
+    return (
+        <MainView title="Code Blocks" description={`A code block is a way for you to run some custom code and keep it around. 
         Is there a feature you want but not supported by PEG? 
         configure it though code and keep it in your keymap as you configure everything else with PEG.
-         This view will let you see your code block `}
-			supported={true}
-			featureType={ShareableFeatureType.codeBlocks}
-		>
-			<div className="flex w-full h-full overflow-scroll">
-				<div className="flex flex-col w-[70%] h-[400px]">
-					<For each={codeBlocks()} fallback={fallBack()}>
-						{(codeBlock, i) => (
-							<div className="mb-3 rounded rounded-lg border pt-4 pr-4 pl-4 pb-3 hover:translate-x-[.65rem] transition">
-								<p className="mb-2 border rounded rounded-md p-3 bg-base-200 text-[.8rem]">
-									<code style="white-space: pre-wrap">
-										# codeblock
-										{codeBlock}# codeblock
-									</code>
-								</p>
-								<div className="flex justify-between w-full">
-									<ShareFeature
-										featureType={ShareableFeatureType.codeBlocks}
-										codeBlock={codeBlock}
-										iconButton
-										btnClasses="btn-outline mr-1"
-									/>
-									{/* delete button here for codeblock, should probably prompt with a modal as well to confirm */}
-									<Button
-										selected={true}
-										onClick={() => {
-											//@ts-ignore
-											clientManager.RemoveCodeBlock(i());
-										}}
-										className="btn btn-ghost hover:btn-error gap-2"
-										icon
-									>
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											class="h-[1.1rem] h-[1.1rem]"
-											fill="none"
-											viewBox="0 0 24 24"
-											stroke="currentColor"
-											stroke-width="2"
-										>
-											<path
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-											/>
-										</svg>
-										Delete
-									</Button>
-								</div>
-							</div>
-						)}
-					</For>
-					{codeBlocks().length > 0 ? (
+         This  view will let you see your code block `} supported={true} featureType={ShareableFeatureType.codeBlocks}>
+            <div className="flex w-full h-full overflow-scroll">
+                <div className="flex flex-col w-[70%] h-[400px]">
+                    <For each={codeBlocks()} fallback={fallBack()}>
+                        {(codeBlock, i) => (
+                            <div className="mb-3 rounded rounded-lg border pt-4 pr-4 pl-4 pb-3 hover:translate-x-[.65rem] transition">
+
+                                <p className='mb-2 border rounded rounded-md p-3 bg-base-200 text-[.8rem]'>
+                                    <code style="white-space: pre-wrap">
+                                        # codeblock
+                                        {codeBlock}
+                                        # codeblock
+                                    </code>
+                                </p>
+                                <div className="flex justify-between w-full">
+                                    <ShareFeature featureType={ShareableFeatureType.codeBlocks} codeBlock={codeBlock} iconButton btnClasses='btn-outline mr-1' />
+                                    {/* delete button here for codeblock, should probably prompt with a modal as well to confirm */}
+                                    <Button
+                                        selected={true}
+                                        onClick={() => {
+                                            //@ts-ignore
+                                            clientManager.RemoveCodeBlock(i())
+                                        }}
+                                        className='btn btn-ghost hover:btn-error gap-2'
+                                        icon
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-[1.1rem] h-[1.1rem]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                        </svg>
+                                        Delete
+                                    </Button>
+                                </div>
+                            </div>
+                        )}
+                    </For>
+                    {codeBlocks().length > 0 ? (
 						<Button
 							onClick={() => {
 								clientManager.sendToBackend(ElectronEvents.OpenFile, "");
@@ -106,8 +88,10 @@ export default function LED() {
 					) : (
 						""
 					)}
-				</div>
-			</div>
-		</MainView>
-	);
+                </div>
+            </div>
+
+        </MainView>
+    )
 }
+

--- a/src/views/codeBlock/codeBlock.tsx
+++ b/src/views/codeBlock/codeBlock.tsx
@@ -1,75 +1,113 @@
-import { createSignal, For, onCleanup, Show } from 'solid-js'
-import DownloadFeature from '../../components/downloadFeature/downloadFeature'
-import MainView from '../../components/mainView/mainView'
-import ShareFeature from '../../components/shareFeature/shareFeature'
-import { KeyMap } from '../../logic/keymapManager'
-import { ShareableFeatureType } from '../../types/types'
-import Button from '../../components/button/button'
-import { ClientManager } from '../../logic/clientManager'
-const clientManager = ClientManager.getInstance()
-const keymap = KeyMap.getInstance()
+import { createSignal, For, onCleanup, Show } from "solid-js";
+import DownloadFeature from "../../components/downloadFeature/downloadFeature";
+import MainView from "../../components/mainView/mainView";
+import ShareFeature from "../../components/shareFeature/shareFeature";
+import { KeyMap } from "../../logic/keymapManager";
+import { ElectronEvents, ShareableFeatureType } from "../../types/types";
+import Button from "../../components/button/button";
+import { ClientManager } from "../../logic/clientManager";
+const clientManager = ClientManager.getInstance();
+const keymap = KeyMap.getInstance();
 
 export default function LED() {
-    const [codeBlocks, setCodeBlock] = createSignal(keymap.codeBlock)
+	const [codeBlocks, setCodeBlock] = createSignal(keymap.codeBlock);
 
-    const subId2 = keymap.Subscribe(() => {
-        setCodeBlock(keymap.codeBlock)
-    })
+	const subId2 = keymap.Subscribe(() => {
+		setCodeBlock(keymap.codeBlock);
+	});
 
-    onCleanup(() => {
-
-        keymap.Unsubscribe(subId2)
-    })
-    const fallBack = () => {
-        return (
-            <p>
-                Your keyboard does not have a code block currently. Download one with the button below or wrap any code in "# codeblock"
-            </p>
-        )
-    }
-    return (
-        <MainView title="Code Blocks" description={`A code block is a way for you to run some custom code and keep it around. 
+	onCleanup(() => {
+		keymap.Unsubscribe(subId2);
+	});
+	const fallBack = () => {
+		return (
+			<div>
+				<p>
+					Your keyboard does not have a code block currently. Download one with
+					the button below or wrap any code in "# codeblock"
+				</p>
+				<Button
+					onClick={() => {
+						clientManager.sendToBackend(ElectronEvents.OpenFile, "");
+					}}
+				>
+					Add Code Blocks
+				</Button>
+			</div>
+		);
+	};
+	console.log("code blocks length", codeBlocks.length);
+	return (
+		<MainView
+			title="Code Blocks"
+			description={`A code block is a way for you to run some custom code and keep it around. 
         Is there a feature you want but not supported by PEG? 
         configure it though code and keep it in your keymap as you configure everything else with PEG.
-         This  view will let you see your code block `} supported={true} featureType={ShareableFeatureType.codeBlocks}>
-            <div className="flex w-full h-full overflow-scroll">
-                <div className="flex flex-col w-[70%] h-[400px]">
-                    <For each={codeBlocks()} fallback={fallBack()}>
-                        {(codeBlock, i) => (
-                            <div className="mb-3 rounded rounded-lg border pt-4 pr-4 pl-4 pb-3 hover:translate-x-[.65rem] transition">
-
-                                <p className='mb-2 border rounded rounded-md p-3 bg-base-200 text-[.8rem]'>
-                                    <code style="white-space: pre-wrap">
-                                        # codeblock
-                                        {codeBlock}
-                                        # codeblock
-                                    </code>
-                                </p>
-                                <div className="flex justify-between w-full">
-                                    <ShareFeature featureType={ShareableFeatureType.codeBlocks} codeBlock={codeBlock} iconButton btnClasses='btn-outline mr-1' />
-                                    {/* delete button here for codeblock, should probably prompt with a modal as well to confirm */}
-                                    <Button
-                                        selected={true}
-                                        onClick={() => {
-                                            //@ts-ignore
-                                            clientManager.RemoveCodeBlock(i())
-                                        }}
-                                        className='btn btn-ghost hover:btn-error gap-2'
-                                        icon
-                                    >
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-[1.1rem] h-[1.1rem]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                                        </svg>
-                                        Delete
-                                    </Button>
-                                </div>
-                            </div>
-                        )}
-                    </For>
-                </div>
-            </div>
-
-        </MainView>
-    )
+         This view will let you see your code block `}
+			supported={true}
+			featureType={ShareableFeatureType.codeBlocks}
+		>
+			<div className="flex w-full h-full overflow-scroll">
+				<div className="flex flex-col w-[70%] h-[400px]">
+					<For each={codeBlocks()} fallback={fallBack()}>
+						{(codeBlock, i) => (
+							<div className="mb-3 rounded rounded-lg border pt-4 pr-4 pl-4 pb-3 hover:translate-x-[.65rem] transition">
+								<p className="mb-2 border rounded rounded-md p-3 bg-base-200 text-[.8rem]">
+									<code style="white-space: pre-wrap">
+										# codeblock
+										{codeBlock}# codeblock
+									</code>
+								</p>
+								<div className="flex justify-between w-full">
+									<ShareFeature
+										featureType={ShareableFeatureType.codeBlocks}
+										codeBlock={codeBlock}
+										iconButton
+										btnClasses="btn-outline mr-1"
+									/>
+									{/* delete button here for codeblock, should probably prompt with a modal as well to confirm */}
+									<Button
+										selected={true}
+										onClick={() => {
+											//@ts-ignore
+											clientManager.RemoveCodeBlock(i());
+										}}
+										className="btn btn-ghost hover:btn-error gap-2"
+										icon
+									>
+										<svg
+											xmlns="http://www.w3.org/2000/svg"
+											class="h-[1.1rem] h-[1.1rem]"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+											stroke-width="2"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+											/>
+										</svg>
+										Delete
+									</Button>
+								</div>
+							</div>
+						)}
+					</For>
+					{codeBlocks().length > 0 ? (
+						<Button
+							onClick={() => {
+								clientManager.sendToBackend(ElectronEvents.OpenFile, "");
+							}}
+						>
+							Edit Code Blocks
+						</Button>
+					) : (
+						""
+					)}
+				</div>
+			</div>
+		</MainView>
+	);
 }
-

--- a/src/views/codeBlock/codeBlock.tsx
+++ b/src/views/codeBlock/codeBlock.tsx
@@ -26,13 +26,7 @@ export default function LED() {
                 <p>
                     Your keyboard does not have a code block currently. Download one with the button below or wrap any code in "# codeblock"
                 </p>
-                <Button
-					onClick={() => {
-						clientManager.sendToBackend(ElectronEvents.OpenFile, "");
-					}}
-				>
-					Add Code Blocks
-				</Button>
+                <Button onClick={() => {clientManager.sendToBackend(ElectronEvents.OpenFile, "")}}>Add Code Blocks</Button>
             </div>
             
 
@@ -78,16 +72,11 @@ export default function LED() {
                         )}
                     </For>
                     {codeBlocks().length > 0 ? (
-						<Button
-							onClick={() => {
-								clientManager.sendToBackend(ElectronEvents.OpenFile, "");
-							}}
-						>
-							Edit Code Blocks
-						</Button>
-					) : (
-						""
-					)}
+			<Button onClick={() => {clientManager.sendToBackend(ElectronEvents.OpenFile, "");}}>
+			    Edit Code Blocks
+			</Button>) 
+		    : ("")
+		    }
                 </div>
             </div>
 


### PR DESCRIPTION
### Feature Description
The current code block view provides little direction to create a code block (at least for me)
Adds button to open board's main.py in OS default editor for .py files to improve experience of creating or editing a code block.

Basic logic:

Disk manager creates a tempKeymapping from the keyboards drive and opens it in the system default for python files. Once the user makes their changes to this tempKeymapping they save the file, which is then detected by peg and the new contents are flashed onto the board by diskmanager.

### Files changed 

main.ts: create handler for editing code blocks 
diskManager.ts:  addCreateTempKeymap function that creates a temporary keymap for the user to edit
types.ts: add new OpenFile ElectronEvents type to support new feature
codeblock.tsx: add buttons, import ElectronEvents

Any feedback would be greatly appreciated and any modifications necessary I would be happy to do.
Thanks for reviewing and the awesome project you've created.